### PR TITLE
Adding SerializationCompatibilityTests from ProductionTests

### DIFF
--- a/src/SerializerCompatibilityTests/Common/Common.csproj
+++ b/src/SerializerCompatibilityTests/Common/Common.csproj
@@ -1,0 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{572499ED-E234-4C66-BD6E-D5A845065C5F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Common</RootNamespace>
+    <AssemblyName>Common</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Paket.Core, Version=2.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Paket.Core.2.5.0\lib\net45\Paket.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ISerializationTester.cs" />
+    <Compile Include="ISerializerFacade.cs" />
+    <Compile Include="NCrunchEnvironment.cs" />
+    <Compile Include="Runner\AppDomains\AppDomainCreator.cs" />
+    <Compile Include="Runner\AppDomains\AppDomainRunner.cs" />
+    <Compile Include="Runner\AppDomains\AssemblyLoader.cs" />
+    <Compile Include="Runner\AppDomains\AssemblyRedirectInfo.cs" />
+    <Compile Include="Runner\AppDomains\AssemblyRedirector.cs" />
+    <Compile Include="Runner\Nuget\PackageVersionComparer.cs" />
+    <Compile Include="Runner\OutputDirectoryCreator.cs" />
+    <Compile Include="Runner\Nuget\NuGetPackageResolver.cs" />
+    <Compile Include="Runner\Nuget\Package.cs" />
+    <Compile Include="Runner\Nuget\PackageInfo.cs" />
+    <Compile Include="Tests\SerializationFormat.cs" />
+    <Compile Include="Tests\ITestCaseFinder.cs" />
+    <Compile Include="Tests\TestCaseFileName.cs" />
+    <Compile Include="Tests\TestCaseFinder.cs" />
+    <Compile Include="Tests\TestCase.cs" />
+    <Compile Include="Tests\TestCases\Failing.cs" />
+    <Compile Include="Tests\TestCases\Passing.cs" />
+    <Compile Include="Tests\TestCases\TestDictionaries.cs" />
+    <Compile Include="Tests\TestCases\TestEvents.cs" />
+    <Compile Include="Tests\TestCases\TestGenericMessage.cs" />
+    <Compile Include="Tests\TestCases\TestInvalidCharacter.cs" />
+    <Compile Include="Tests\TestCases\TestLists.cs" />
+    <Compile Include="Tests\TestCases\TestPoco.cs" />
+    <Compile Include="Tests\TestCases\TestPolymorphicCollections.cs" />
+    <Compile Include="Tests\TestCases\TestXmlSpecialCharacters.cs" />
+    <Compile Include="Tests\TestCases\Types\GenericMessage.cs" />
+    <Compile Include="Tests\TestCases\Types\ISampleEvent.cs" />
+    <Compile Include="Tests\TestCases\Types\MessageWithInvalidCharacter.cs" />
+    <Compile Include="Tests\TestCases\Types\MessageWithLists.cs" />
+    <Compile Include="Tests\TestCases\Types\PolymorphicCollection.cs" />
+    <Compile Include="Tests\TestCases\Types\TestMessageWithChar.cs" />
+    <Compile Include="Tests\TestCases\Types\MessageWithDictionaries.cs" />
+    <Compile Include="Tests\TestCases\Types\Person.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/SerializerCompatibilityTests/Common/Common.csproj.DotSettings
+++ b/src/SerializerCompatibilityTests/Common/Common.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>

--- a/src/SerializerCompatibilityTests/Common/ISerializationTester.cs
+++ b/src/SerializerCompatibilityTests/Common/ISerializationTester.cs
@@ -1,0 +1,14 @@
+﻿namespace Common
+{
+    using System;
+    using Tests;
+
+    public interface ISerializationTester
+    {
+        //HINT: we are passing type of test case to make sure that during the test
+        //      testcase instance is create in app domain spawn for each nsb version.
+        //      This is important as NSB dynamically creates types for interfaces.
+        void Serialize(Type testCase, SerializationFormat format, string filePath);
+        void Verify(Type testCase, SerializationFormat format, string filePath);
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/ISerializerFacade.cs
+++ b/src/SerializerCompatibilityTests/Common/ISerializerFacade.cs
@@ -1,0 +1,12 @@
+﻿namespace Common
+{
+    using System;
+    using System.IO;
+
+    public interface ISerializerFacade
+    {
+        void Serialize(Stream stream, object instance);
+        object[] Deserialize(Stream stream);
+        object CreateInstance(Type type);
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/NCrunchEnvironment.cs
+++ b/src/SerializerCompatibilityTests/Common/NCrunchEnvironment.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+/// <summary>
+/// This class is taken from the NCrunch helper assembly. It is needed to access the NCrunch-specific workspacing
+/// locations, so the appdomains correctly load assemblies
+/// when running under NCrunch.
+/// </summary>
+static class NCrunchEnvironment
+{
+    public static bool NCrunchIsResident()
+    {
+        return Environment.GetEnvironmentVariable("NCrunch") == "1";
+    }
+
+    public static string GetOriginalSolutionPath()
+    {
+        return Environment.GetEnvironmentVariable("NCrunch.OriginalSolutionPath");
+    }
+
+    public static string GetOriginalProjectPath()
+    {
+        return Environment.GetEnvironmentVariable("NCrunch.OriginalProjectPath");
+    }
+
+    public static string[] GetImplicitlyReferencedAssemblyLocations()
+    {
+        var environmentVariable = Environment.GetEnvironmentVariable("NCrunch.ImplicitlyReferencedAssemblyLocations");
+        return environmentVariable?.Split(';');
+    }
+
+    public static string[] GetAllAssemblyLocations()
+    {
+        var environmentVariable = Environment.GetEnvironmentVariable("NCrunch.AllAssemblyLocations");
+        return environmentVariable?.Split(';');
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AppDomainCreator.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AppDomainCreator.cs
@@ -1,0 +1,90 @@
+﻿namespace Common.Runner.AppDomains
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using Nuget;
+    using Paket;
+
+    [Serializable]
+    public class AppDomainCreator
+    {
+        public AppDomainDescriptor CreateDomain(string startupDirTemplate, Package package)
+        {
+            var startupDir = CreateStartupDir(startupDirTemplate, package.Version, Guid.NewGuid());
+
+            var sourceAssemblyDir = package.Info.PackageName + SemVer.Parse(package.Version).Major;
+            var sourceAssemblyFiles = Directory.GetFiles(sourceAssemblyDir, "*");
+
+            CopyAssembliesToStarupDir(startupDir, sourceAssemblyFiles, package.Files);
+
+            var appDomain = AppDomain.CreateDomain(
+                $"{package.Info.PackageName} {package.Version}",
+                null,
+                new AppDomainSetup
+                {
+                    ApplicationBase = startupDir.FullName
+                });
+
+            SetupBindingRedirects(package, appDomain);
+
+            appDomain.SetData("FriendlyName", appDomain.FriendlyName);
+
+            return new AppDomainDescriptor
+            {
+                AppDomain = appDomain,
+                ProjectAssemblyPath = Path.Combine(startupDir.FullName, sourceAssemblyDir + ".dll"),
+                PackageVersion = package.Version
+            };
+        }
+
+        static void SetupBindingRedirects(Package package, AppDomain appDomain)
+        {
+            var assemblyRedirector = new CustomAssemblyLoader(appDomain);
+
+            foreach (var assembly in package.Files)
+            {
+                var assemblyName = AssemblyName.GetAssemblyName(assembly.FullName);
+                var token = assemblyName.GetPublicKeyToken();
+                var shortName = assemblyName.Name;
+                var version = assemblyName.Version;
+
+                assemblyRedirector.AddAssemblyRedirect(shortName, version, token);
+            }
+        }
+
+        void CopyAssembliesToStarupDir(DirectoryInfo destination, string[] baseFiles, FileInfo[] overrides)
+        {
+            foreach (var file in baseFiles)
+            {
+                var newFilename = Path.Combine(destination.FullName, Path.GetFileName(file));
+
+                File.Copy(file, newFilename);
+            }
+
+            foreach (var @override in overrides)
+            {
+                @override.CopyTo(Path.Combine(destination.FullName, @override.Name), true);
+            }
+        }
+
+        static DirectoryInfo CreateStartupDir(string codeBaseDirTemplate, string version, Guid uniqueId)
+        {
+            var directoryName = string.Format(codeBaseDirTemplate, version, uniqueId);
+
+            if (Directory.Exists(directoryName) == false)
+            {
+                return Directory.CreateDirectory(directoryName);
+            }
+
+            return new DirectoryInfo(directoryName);
+        }
+    }
+
+    public class AppDomainDescriptor
+    {
+        public AppDomain AppDomain { get; set; }
+        public string ProjectAssemblyPath { get; set; }
+        public string PackageVersion { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AppDomainRunner.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AppDomainRunner.cs
@@ -1,0 +1,23 @@
+﻿namespace Common.Runner.AppDomains
+{
+    using System;
+
+    public class AppDomainRunner
+    {
+        public AppDomainRunner(AppDomainDescriptor appDomainDescriptor)
+        {
+            this.appDomainDescriptor = appDomainDescriptor;
+        }
+
+        public string PackageVersion => appDomainDescriptor.PackageVersion;
+
+        public void Run(Action<ISerializationTester> action)
+        {
+            var appDomainEntry = (ISerializationTester)appDomainDescriptor.AppDomain.CreateInstanceFromAndUnwrap(appDomainDescriptor.ProjectAssemblyPath, "Tester");
+
+            action(appDomainEntry);
+        }
+
+        readonly AppDomainDescriptor appDomainDescriptor;
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AssemblyLoader.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AssemblyLoader.cs
@@ -1,0 +1,67 @@
+﻿namespace Common.Runner.AppDomains
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+
+    public class AssemblyLoader : MarshalByRefObject
+    {
+        // ReSharper disable once EmptyConstructor
+        public AssemblyLoader()
+        {
+#if NCRUNCH
+    // This code isn't needed for other test runners or NCrunch with the 
+    // 'Copy Referenced Assemblies To Workspace' setting enabled, because they 
+    // will have the ReferencedProject.dll sitting in the current directory.
+    // see https://www.ncrunch.net/documentation/troubleshooting_tests-that-build-their-own-appdomains
+
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+#endif
+        }
+
+        public void LoadAssembly(string assemblyFile)
+        {
+            try
+            {
+                Assembly.LoadFrom(assemblyFile);
+            }
+            catch (FileNotFoundException)
+            {
+                // continue loading no matter what
+            }
+        }
+
+        public IEnumerable<AssemblyName> GetLoadedAssemblies()
+        {
+            return AppDomain.CurrentDomain.GetAssemblies().Select(assembly => assembly.GetName()).ToList();
+        }
+
+#if NCRUNCH
+        private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            // Search through the known assembly locations returned from the NCrunchEnvironment.GetAllAssemblyLocations method, 
+            // and load any assembly with a name matching the one we're looking for
+
+            var shortAssemblyName = getShortAssemblyName(args.Name);
+
+            foreach (var knownAssemblyLocation in NCrunchEnvironment.GetAllAssemblyLocations())
+                if (string.Compare(Path.GetFileNameWithoutExtension(knownAssemblyLocation), shortAssemblyName, true) == 0)
+                    return Assembly.LoadFrom(knownAssemblyLocation);
+
+            return null;
+        }
+
+        private static string getShortAssemblyName(string assemblyName)
+        {
+            // The CLR can attempt to resolve assemblies using long names - so we truncate the name to make matching easier.
+
+            if (assemblyName.Contains(","))
+                return assemblyName.Substring(0, assemblyName.IndexOf(','));
+
+            return assemblyName;
+        }
+#endif
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AssemblyRedirectInfo.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AssemblyRedirectInfo.cs
@@ -1,0 +1,11 @@
+﻿namespace Common.Runner.AppDomains
+{
+    using System;
+
+    public class AssemblyRedirectInfo
+    {
+        public string ShortName;
+        public Version Version;
+        public string PublicKeyToken;
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AssemblyRedirector.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/AppDomains/AssemblyRedirector.cs
@@ -1,0 +1,61 @@
+namespace Common.Runner.AppDomains
+{
+    using System;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Reflection;
+
+    [Serializable]
+    public class CustomAssemblyLoader
+    {
+        public CustomAssemblyLoader(AppDomain appDomain)
+        {
+            this.appDomain = appDomain;
+        }
+
+        public void AddAssemblyRedirect(string shortName, Version targetVersion, byte[] publicKeyToken)
+        {
+            var resolver = new BindingRedirectResolver(appDomain, shortName, targetVersion, publicKeyToken);
+
+            appDomain.AssemblyResolve += resolver.Resolve;
+        }
+
+        AppDomain appDomain;
+
+        [Serializable]
+        class BindingRedirectResolver
+        {
+            public BindingRedirectResolver(AppDomain domain, string shortName, Version targetVersion, byte[] publicKeyToken)
+            {
+                this.domain = domain;
+                this.shortName = shortName;
+                this.targetVersion = targetVersion;
+                this.publicKeyToken = publicKeyToken;
+            }
+
+            public Assembly Resolve(object sender, ResolveEventArgs args)
+            {
+                // Use latest strong name & version when trying to load SDK assemblies
+                var requestedAssembly = new AssemblyName(args.Name);
+                if (requestedAssembly.Name != shortName)
+                    return null;
+
+                Debug.WriteLine("Redirecting assembly load of " + args.Name
+                                + ",\tloaded by " + (args.RequestingAssembly?.FullName ?? "(unknown)"));
+
+                requestedAssembly.Version = targetVersion;
+                requestedAssembly.SetPublicKeyToken(publicKeyToken);
+                requestedAssembly.CultureInfo = CultureInfo.InvariantCulture;
+
+                domain.AssemblyResolve -= Resolve;
+
+                return Assembly.Load(requestedAssembly);
+            }
+
+            readonly AppDomain domain;
+            byte[] publicKeyToken;
+            string shortName;
+            Version targetVersion;
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/Nuget/NuGetPackageResolver.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/Nuget/NuGetPackageResolver.cs
@@ -1,0 +1,104 @@
+﻿namespace Common.Runner.Nuget
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.FSharp.Control;
+    using Microsoft.FSharp.Core;
+    using Paket;
+
+    public class NuGetPackageResolver
+    {
+        public NuGetPackageResolver(string packagesStore, string nugetFeed = Constants.DefaultNugetStream)
+        {
+            this.packagesStore = packagesStore;
+            this.nugetFeed = nugetFeed;
+        }
+
+        public async Task<Package> DownloadPackageWithDependencies(PackageInfo packageInfo)
+        {
+            var latesVersion = await GetLatestPackageVersion(packageInfo);
+            var version = SemVer.Parse(latesVersion);
+
+            var packageLocation = await DownloadPackage(packageInfo, version);
+            var dependencies = await GetAllDependencies(packageInfo, version);
+
+            var files = NuGetV2.GetLibFiles(packageLocation).Concat(dependencies);
+
+            var package = new Package
+            {
+                Info = packageInfo,
+                Version = latesVersion,
+                Files = files.Where(f => Path.GetExtension(f.Name) == ".dll").ToArray()
+            };
+
+            return package;
+        }
+
+        async Task<string> GetLatestPackageVersion(PackageInfo packageInfo)
+        {
+            var requirement = VersionRequirement.Parse(packageInfo.VersionConstraint);
+            var versions = await GetAllVersions(packageInfo.PackageName);
+            var matchingVersions = versions.Where(v => requirement.IsInRange(v, FSharpOption<bool>.None)).ToList();
+            return matchingVersions.Max().AsString;
+        }
+
+        async Task<IEnumerable<FileInfo>> GetAllDependencies(PackageInfo package, SemVerInfo version)
+        {
+            var packageDetails = await GetPackageDetails(package.PackageName, version);
+
+            var fileInfos = new List<FileInfo>();
+
+            var dependencies = packageDetails.Dependencies.Select(d => new PackageInfo(d.Item1.ToString(), d.Item2.FormatInNuGetSyntax()));
+
+            foreach (var dependency in dependencies)
+            {
+                var result = await DownloadPackageWithDependencies(dependency);
+
+                fileInfos.AddRange(result.Files);
+            }
+
+            return fileInfos;
+        }
+
+        async Task<string> DownloadPackage(PackageInfo package, SemVerInfo version)
+        {
+            var result = await FSharpAsync.StartAsTask(
+                NuGetV2.DownloadPackage(packagesStore,
+                    FSharpOption<Utils.Auth>.None,
+                    nugetFeed,
+                    Domain.GroupName("default"),
+                    Domain.PackageName(package.PackageName),
+                    version,
+                    includeVersionInPath: true,
+                    force: false),
+                FSharpOption<TaskCreationOptions>.None,
+                FSharpOption<CancellationToken>.None);
+            return result;
+        }
+
+        async Task<NuGetV2.NugetPackageCache> GetPackageDetails(string packageName, SemVerInfo version)
+        {
+            var result = await FSharpAsync.StartAsTask(
+                NuGetV2.getDetailsFromNuGet(true, FSharpOption<Utils.Auth>.None, nugetFeed, Domain.PackageName(packageName), version),
+                FSharpOption<TaskCreationOptions>.None,
+                FSharpOption<CancellationToken>.None);
+
+            return result;
+        }
+
+        async Task<IEnumerable<SemVerInfo>> GetAllVersions(string packageName)
+        {
+            var result = await FSharpAsync.StartAsTask(
+                NuGetV2.getAllVersions(FSharpOption<Utils.Auth>.None, nugetFeed, packageName),
+                FSharpOption<TaskCreationOptions>.None,
+                FSharpOption<CancellationToken>.None);
+            return result.Value.Select(SemVer.Parse);
+        }
+
+        readonly string packagesStore;
+        readonly string nugetFeed;
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/Nuget/Package.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/Nuget/Package.cs
@@ -1,0 +1,13 @@
+﻿namespace Common.Runner.Nuget
+{
+    using System.IO;
+
+    public class Package
+    {
+        public PackageInfo Info { get; set; }
+
+        public string Version { get; set; }
+
+        public FileInfo[] Files { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/Nuget/PackageInfo.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/Nuget/PackageInfo.cs
@@ -1,0 +1,31 @@
+﻿namespace Common.Runner.Nuget
+{
+    using System;
+
+    [Serializable]
+    public class PackageInfo
+    {
+        public PackageInfo(string packageName, string versionConstraint = null)
+        {
+            PackageName = packageName;
+            VersionConstraint = versionConstraint;
+        }
+
+        public string PackageName { get; }
+        public string VersionConstraint { get; }
+
+        public static implicit operator PackageInfo(string package)
+        {
+            var pair = package.Split(':');
+            if (pair.Length == 2)
+                return new PackageInfo(pair[0], pair[1]);
+
+            throw new ArgumentException($"The value '{package}' is not in a correct format. Use 'PackageName:VersionConstraint[:pre]'.");
+        }
+
+        public override string ToString()
+        {
+            return $"{PackageName} {VersionConstraint}";
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/Nuget/PackageVersionComparer.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/Nuget/PackageVersionComparer.cs
@@ -1,0 +1,17 @@
+﻿namespace Common.Runner.Nuget
+{
+    using System.Collections.Generic;
+
+    public class PackageVersionComparer : IEqualityComparer<Package>
+    {
+        public bool Equals(Package x, Package y)
+        {
+            return x.Version == y.Version;
+        }
+
+        public int GetHashCode(Package obj)
+        {
+            return obj.Version.GetHashCode();
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Runner/OutputDirectoryCreator.cs
+++ b/src/SerializerCompatibilityTests/Common/Runner/OutputDirectoryCreator.cs
@@ -1,0 +1,33 @@
+﻿namespace Common.Runner
+{
+    using System;
+    using System.IO;
+
+    public class OutputDirectoryCreator
+    {
+        public string SetupOutputDirectory(string name)
+        {
+            var outputDirectory = Path.Combine(AppDomain.CurrentDomain.SetupInformation.ApplicationBase, name);
+
+            if (Directory.Exists(outputDirectory) == false)
+            {
+                Directory.CreateDirectory(outputDirectory);
+            }
+
+            /*
+            var directoryInfo = new DirectoryInfo(outputDirectory);
+
+            foreach (var fileInfo in directoryInfo.GetFiles())
+            {
+                fileInfo.Delete();
+            }
+
+            foreach (var directory in directoryInfo.GetDirectories())
+            {
+                directory.Delete(true);
+            }
+            */
+            return outputDirectory;
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/ITestCaseFinder.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/ITestCaseFinder.cs
@@ -1,0 +1,9 @@
+﻿namespace Common.Tests
+{
+    using System.Collections.Generic;
+
+    public interface ITestCaseFinder
+    {
+        List<TestCase> Find(string appDomainName);
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/SerializationFormat.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/SerializationFormat.cs
@@ -1,0 +1,8 @@
+﻿namespace Common.Tests
+{
+    public enum SerializationFormat
+    {
+        Xml,
+        Json
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCase.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCase.cs
@@ -1,0 +1,16 @@
+﻿namespace Common.Tests
+{
+    using System;
+
+    public abstract class TestCase : MarshalByRefObject
+    {
+        public abstract Type MessageType { get; }
+        public virtual bool SupportsVersion(string version) => true;
+
+        public virtual bool SupportsFormat(SerializationFormat format) => true;
+
+        public abstract void Populate(object instance);
+
+        public abstract void CheckIfAreEqual(object instanceA, object instanceB);
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCaseFileName.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCaseFileName.cs
@@ -1,0 +1,23 @@
+﻿namespace Common.Tests
+{
+    public class TestCaseFileName
+    {
+        public TestCaseFileName(string nsbVersion, string testCaseName, SerializationFormat format)
+        {
+            this.nsbVersion = nsbVersion;
+
+            TestCaseName = testCaseName;
+            Format = format;
+        }
+
+        string nsbVersion { get; }
+        public string TestCaseName { get; }
+
+        public SerializationFormat Format { get; }
+
+        public override string ToString()
+        {
+            return $"NServiceBus {nsbVersion}_{TestCaseName}_.{Format}";
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCaseFinder.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCaseFinder.cs
@@ -1,0 +1,19 @@
+﻿namespace Common.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NUnit.Framework;
+
+    public class TestCaseFinder
+    {
+        public List<TestCase> FindAll()
+        {
+            var testCaseTypes = typeof(TestCase).Assembly.GetTypes().Where(type => type.IsSubclassOf(typeof(TestCase)) && !Attribute.IsDefined(type, typeof(IgnoreAttribute)));
+
+            var allTestCases = testCaseTypes.Select(type => (TestCase)Activator.CreateInstance(type));
+
+            return allTestCases.ToList();
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Failing.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Failing.cs
@@ -1,0 +1,28 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using NUnit.Framework;
+    using Types;
+
+    public class Failing : TestCase
+    {
+        public override Type MessageType => typeof(Person);
+
+
+        //HINT: we need to put it and Passing here as Test.dll is not loaded into each custom nsb appdomains
+        //      only Common.dll is. It should never run with other serialization test cases.
+        public override bool SupportsVersion(string version)
+        {
+            return false;
+        }
+
+        public override void Populate(object instance)
+        {
+        }
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+            Assert.AreEqual("0", "1");
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Passing.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Passing.cs
@@ -1,0 +1,25 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using Types;
+
+    public class Passing : TestCase
+    {
+        public override Type MessageType => typeof(Person);
+
+        //HINT: we need to put it and Passing here as Test.dll is not loaded into each custom nsb appdomains
+        //      only Common.dll is. It should never run with other serialization test cases.
+        public override bool SupportsVersion(string version)
+        {
+            return false;
+        }
+
+        public override void Populate(object instance)
+        {
+        }
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestDictionaries.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestDictionaries.cs
@@ -1,0 +1,133 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using NUnit.Framework;
+    using Types;
+
+    public class TestDictionaries : TestCase
+    {
+        public override Type MessageType => typeof(MessageWithDictionaries);
+
+        public override void Populate(object instance)
+        {
+            var dictionary = (MessageWithDictionaries)instance;
+
+            dictionary.Bools = new Dictionary<bool, bool>
+            {
+                { true, true },
+                { false, false }
+            };
+            dictionary.Chars = new Dictionary<char, char>
+            {
+                //{char.MinValue, char.MaxValue}, // doesn't work because we use UTF8
+                { 'a', 'b' },
+                { 'c', 'd' },
+                { 'e', 'f' }
+            };
+            dictionary.Bytes = new Dictionary<byte, byte>
+            {
+                { byte.MinValue, byte.MaxValue },
+                { 11, 1 },
+                { 1, 0 }
+            };
+            dictionary.Ints = new Dictionary<int, int>
+            {
+                { int.MinValue, int.MaxValue },
+                { 1, 2 },
+                { 3, 4 },
+                { 5, 6 }
+            };
+            dictionary.Decimals = new Dictionary<decimal, decimal>
+            {
+                { decimal.MinValue, decimal.MaxValue },
+                { .2m, 4m },
+                { .5m, .4234m }
+            };
+            dictionary.Doubles = new Dictionary<double, double>
+            {
+                //HINT: double.MinValue and double.MaxValue stored as keys in dictionary cannot be properly serialized by Json.Net
+                { 0, double.MinValue },
+                { 1, double.MaxValue },
+                { .223d, 234d },
+                { .513d, .4212334d }
+            };
+            dictionary.Floats = new Dictionary<float, float>
+            {
+                //HINT: float.MinValue and float.MaxValue stored as keys in dictioanry cannot be properly serialized by Json.Net
+                { 0, float.MaxValue },
+                { 1, float.MinValue },
+                { .223f, 234f },
+                { .513f, .4212334f }
+            };
+            dictionary.Enums = new Dictionary<DateTimeStyles, DateTimeKind>
+            {
+                { DateTimeStyles.AdjustToUniversal, DateTimeKind.Local },
+                { DateTimeStyles.AllowLeadingWhite, DateTimeKind.Unspecified }
+            };
+            dictionary.Longs = new Dictionary<long, long>
+            {
+                { long.MaxValue, long.MinValue },
+                { 34234, 234324 },
+                { 45345345, 34534534565 }
+            };
+            dictionary.SBytes = new Dictionary<sbyte, sbyte>
+            {
+                { sbyte.MaxValue, sbyte.MaxValue },
+                { 56, 13 }
+            };
+            dictionary.Shorts = new Dictionary<short, short>
+            {
+                { short.MinValue, short.MaxValue },
+                { 5231, 6123 }
+            };
+            dictionary.Strings = new Dictionary<string, string>
+            {
+                { "Key1", "Value1" },
+                { "Key2", "Value2" },
+                { "Key3", "Value3" }
+            };
+            dictionary.UInts = new Dictionary<uint, uint>
+            {
+                { uint.MinValue, 23 },
+                { uint.MaxValue, 34324 }
+            };
+            dictionary.ULongs = new Dictionary<ulong, ulong>
+            {
+                //HINT: unsigned ulong cannot be properly deserialized by Json.Net
+                //      see: http://stackoverflow.com/questions/9355091/json-net-crashes-when-serializing-unsigned-integer-ulong-array
+                //      looks like JSON format constraint
+                //{ulong.MinValue, ulong.MaxValue},
+                { 34324234, 3243243245 }
+            };
+            dictionary.UShorts = new Dictionary<ushort, ushort>
+            {
+                { ushort.MinValue, ushort.MaxValue },
+                { 42324, 32 }
+            };
+        }
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+            var expected = (MessageWithDictionaries)instanceA;
+            var result = (MessageWithDictionaries)instanceB;
+
+            CollectionAssert.AreEqual(expected.Bools, result.Bools);
+            CollectionAssert.AreEqual(expected.Chars, result.Chars);
+            CollectionAssert.AreEqual(expected.Bytes, result.Bytes);
+            CollectionAssert.AreEqual(expected.Ints, result.Ints);
+            CollectionAssert.AreEqual(expected.Decimals, result.Decimals);
+            CollectionAssert.AreEqual(expected.Doubles, result.Doubles);
+            CollectionAssert.AreEqual(expected.Floats, result.Floats);
+            CollectionAssert.AreEqual(expected.Enums, result.Enums);
+            CollectionAssert.AreEqual(expected.Longs, result.Longs);
+            CollectionAssert.AreEqual(expected.SBytes, result.SBytes);
+            CollectionAssert.AreEqual(expected.Shorts, result.Shorts);
+            CollectionAssert.AreEqual(expected.Strings, result.Strings);
+            CollectionAssert.AreEqual(expected.UInts, result.UInts);
+            CollectionAssert.AreEqual(expected.ULongs, result.ULongs);
+            CollectionAssert.AreEqual(expected.UShorts, result.UShorts);
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestEvents.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestEvents.cs
@@ -1,0 +1,26 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using NUnit.Framework;
+    using Types;
+
+    public class TestEvents : TestCase
+    {
+        public override Type MessageType => typeof(ISampleEvent);
+
+        public override void Populate(object instance)
+        {
+            var expected = (ISampleEvent)instance;
+
+            expected.Value = "Test Value";
+        }
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+            var expected = (ISampleEvent)instanceA;
+            var other = (ISampleEvent)instanceB;
+
+            Assert.AreEqual(expected.Value, other.Value);
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestGenericMessage.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestGenericMessage.cs
@@ -1,0 +1,30 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using NUnit.Framework;
+    using Types;
+
+    [Ignore]
+    public class TestGenericMessage : TestCase
+    {
+        public override Type MessageType => typeof(GenericMessage<int, string>);
+
+        public override void Populate(object instance)
+        {
+            var expected = (GenericMessage<int, string>)instance;
+
+            expected.SagaId = Guid.NewGuid();
+            expected.Data1 = 1234;
+            expected.Data2 = "Lorem ipsum";
+        }
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+            var expected = (GenericMessage<int, string>)instanceA;
+            var result = (GenericMessage<int, string>)instanceB;
+
+            Assert.AreEqual(expected.Data1, result.Data1);
+            Assert.AreEqual(expected.Data1, result.Data2);
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestInvalidCharacter.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestInvalidCharacter.cs
@@ -1,0 +1,37 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using System.Text;
+    using NUnit.Framework;
+    using Types;
+
+    public class TestInvalidCharacter : TestCase
+    {
+        public override Type MessageType => typeof(MessageWithInvalidCharacter);
+
+        public override bool SupportsVersion(string version)
+        {
+            return !version.StartsWith("3.3");
+        }
+
+        public override void Populate(object instance)
+        {
+            var expected = (MessageWithInvalidCharacter)instance;
+
+            var sb = new StringBuilder();
+            sb.Append("Hello");
+            sb.Append((char)0x1C);
+            sb.Append("John");
+
+            expected.Special = sb.ToString();
+        }
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+            var expected = (MessageWithInvalidCharacter)instanceA;
+            var result = (MessageWithInvalidCharacter)instanceB;
+
+            Assert.AreEqual(expected.Special, result.Special);
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestLists.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestLists.cs
@@ -1,0 +1,166 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using NUnit.Framework;
+    using Types;
+
+    public class TestLists : TestCase
+    {
+        public override Type MessageType => typeof(MessageWithLists);
+
+        public override void Populate(object instance)
+        {
+            var expected = (MessageWithLists)instance;
+
+            expected.Bools = new List<bool>
+            {
+                true,
+                false
+            };
+            expected.Chars = new List<char>
+            {
+                'a',
+                'b',
+                'c',
+                'd',
+                'e',
+                'f'
+            };
+            expected.Bytes = new List<byte>
+            {
+                byte.MinValue,
+                byte.MaxValue,
+                11,
+                1,
+                1,
+                0
+            };
+            expected.Ints = new List<int>
+            {
+                int.MinValue,
+                int.MaxValue,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+            };
+            expected.Decimals =
+                new List<decimal>
+                {
+                    decimal.MinValue,
+                    decimal.MaxValue,
+                    .2m,
+                    4m,
+                    .5m,
+                    .4234m
+                };
+            expected.Doubles =
+                new List<double>
+                {
+                    double.MinValue,
+                    double.MaxValue,
+                    .223d,
+                    234d,
+                    .513d,
+                    .4212334d
+                };
+            expected.Floats =
+                new List<float>
+                {
+                    float.MinValue,
+                    float.MaxValue,
+                    .223f,
+                    234f,
+                    .513f,
+                    .4212334f
+                };
+            expected.Enums = new List<DateTimeStyles>
+            {
+                DateTimeStyles.AdjustToUniversal,
+                DateTimeStyles.AllowLeadingWhite,
+                DateTimeStyles.AllowTrailingWhite
+            };
+            expected.Longs =
+                new List<long>
+                {
+                    long.MaxValue,
+                    long.MinValue,
+                    34234,
+                    234324,
+                    45345345,
+                    34534534565
+                };
+            expected.SBytes = new List<sbyte>
+            {
+                sbyte.MaxValue,
+                sbyte.MaxValue,
+                56,
+                13
+            };
+            expected.Shorts = new List<short>
+            {
+                short.MinValue,
+                short.MaxValue,
+                5231,
+                6123
+            };
+            expected.Strings = new List<string>
+            {
+                "Key1",
+                "Value1",
+                "Key2",
+                "Value2",
+                "Key3",
+                "Value3"
+            };
+            expected.UInts = new List<uint>
+            {
+                uint.MinValue,
+                23,
+                uint.MaxValue,
+                34324
+            };
+            expected.ULongs = new List<ulong>
+            {
+                //HINT: max ulong values are not supported by JSON format
+                //ulong.MinValue,
+                //ulong.MaxValue,
+                34324234,
+                3243243245
+            };
+            expected.UShorts = new List<ushort>
+            {
+                ushort.MinValue,
+                ushort.MaxValue,
+                42324,
+                32
+            };
+        }
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+            var expected = (MessageWithLists)instanceA;
+            var result = (MessageWithLists)instanceB;
+
+            CollectionAssert.AreEqual(expected.Bools, result.Bools);
+            CollectionAssert.AreEqual(expected.Chars, result.Chars);
+            CollectionAssert.AreEqual(expected.Bytes, result.Bytes);
+            CollectionAssert.AreEqual(expected.Ints, result.Ints);
+            CollectionAssert.AreEqual(expected.Decimals, result.Decimals);
+            CollectionAssert.AreEqual(expected.Doubles, result.Doubles);
+            CollectionAssert.AreEqual(expected.Floats, result.Floats);
+            CollectionAssert.AreEqual(expected.Enums, result.Enums);
+            CollectionAssert.AreEqual(expected.Longs, result.Longs);
+            CollectionAssert.AreEqual(expected.SBytes, result.SBytes);
+            CollectionAssert.AreEqual(expected.Shorts, result.Shorts);
+            CollectionAssert.AreEqual(expected.Strings, result.Strings);
+            CollectionAssert.AreEqual(expected.UInts, result.UInts);
+            CollectionAssert.AreEqual(expected.ULongs, result.ULongs);
+            CollectionAssert.AreEqual(expected.UShorts, result.UShorts);
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestPoco.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestPoco.cs
@@ -1,0 +1,28 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using NUnit.Framework;
+    using Types;
+
+    public class TestPoco : TestCase
+    {
+        public override Type MessageType => typeof(Person);
+
+        public override void Populate(object instance)
+        {
+            var expected = (Person)instance;
+
+            expected.FirstName = "John";
+            expected.LastName = "Smith";
+        }
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+            var expected = (Person)instanceA;
+            var other = (Person)instanceB;
+
+            Assert.AreEqual(expected.FirstName, other.FirstName);
+            Assert.AreEqual(expected.LastName, other.LastName);
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestPolymorphicCollections.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestPolymorphicCollections.cs
@@ -1,0 +1,42 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using Types;
+
+    public class TestPolymorphicCollections : TestCase
+    {
+        public override Type MessageType => typeof(PolymorphicCollection);
+
+        public override bool SupportsFormat(SerializationFormat format)
+        {
+            return format == SerializationFormat.Json;
+        }
+
+        public override void Populate(object instance)
+        {
+            var expcected = (PolymorphicCollection)instance;
+
+            expcected.Items = new List<BaseEntity>
+            {
+                new SpecializationA
+                {
+                    Name = "A"
+                },
+                new SpecializationB
+                {
+                    Name = "B"
+                }
+            };
+        }
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+            var expected = (PolymorphicCollection)instanceA;
+            var pc = (PolymorphicCollection)instanceB;
+
+            CollectionAssert.AreEqual(expected.Items, pc.Items);
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestXmlSpecialCharacters.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/TestXmlSpecialCharacters.cs
@@ -1,0 +1,34 @@
+﻿namespace Common.Tests.TestCases
+{
+    using System;
+    using NUnit.Framework;
+    using Types;
+
+    public class TestXmlSpecialCharacters : TestCase
+    {
+        public override Type MessageType => typeof(TestMessageWithChar);
+
+        public override bool SupportsVersion(string version)
+        {
+            return !version.StartsWith("3.3");
+        }
+
+        public override void Populate(object instance)
+        {
+            var expected = (TestMessageWithChar)instance;
+
+            expected.ValidCharacter = 'a';
+            expected.InvalidCharacter = '<';
+        }
+
+
+        public override void CheckIfAreEqual(object instanceA, object instanceB)
+        {
+            var expected = (TestMessageWithChar)instanceA;
+            var message = (TestMessageWithChar)instanceB;
+
+            Assert.AreEqual(expected.ValidCharacter, message.ValidCharacter);
+            Assert.AreEqual(expected.InvalidCharacter, message.InvalidCharacter);
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/GenericMessage.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/GenericMessage.cs
@@ -1,0 +1,21 @@
+﻿namespace Common.Tests.TestCases.Types
+{
+    using System;
+
+    [Serializable]
+    public class GenericMessage<T1, T2>
+    {
+        public GenericMessage(Guid sagaId, T1 data1, T2 data2)
+        {
+            SagaId = sagaId;
+            Data1 = data1;
+            Data2 = data2;
+        }
+
+        public Guid SagaId { get; set; }
+
+        public T1 Data1 { get; set; }
+
+        public T2 Data2 { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/ISampleEvent.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/ISampleEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace Common.Tests.TestCases.Types
+{
+    public interface ISampleEvent
+    {
+        string Value { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/MessageWithDictionaries.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/MessageWithDictionaries.cs
@@ -1,0 +1,26 @@
+namespace Common.Tests.TestCases.Types
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+
+    [Serializable]
+    public class MessageWithDictionaries
+    {
+        public Dictionary<bool, bool> Bools { get; set; }
+        public Dictionary<byte, byte> Bytes { get; set; }
+        public Dictionary<char, char> Chars { get; set; }
+        public Dictionary<decimal, decimal> Decimals { get; set; }
+        public Dictionary<double, double> Doubles { get; set; }
+        public Dictionary<DateTimeStyles, DateTimeKind> Enums { get; set; }
+        public Dictionary<float, float> Floats { get; set; }
+        public Dictionary<int, int> Ints { get; set; }
+        public Dictionary<long, long> Longs { get; set; }
+        public Dictionary<sbyte, sbyte> SBytes { get; set; }
+        public Dictionary<short, short> Shorts { get; set; }
+        public Dictionary<uint, uint> UInts { get; set; }
+        public Dictionary<ulong, ulong> ULongs { get; set; }
+        public Dictionary<ushort, ushort> UShorts { get; set; }
+        public Dictionary<string, string> Strings { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/MessageWithInvalidCharacter.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/MessageWithInvalidCharacter.cs
@@ -1,0 +1,10 @@
+﻿namespace Common.Tests.TestCases.Types
+{
+    using System;
+
+    [Serializable]
+    public class MessageWithInvalidCharacter
+    {
+        public string Special { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/MessageWithLists.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/MessageWithLists.cs
@@ -1,0 +1,26 @@
+﻿namespace Common.Tests.TestCases.Types
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+
+    [Serializable]
+    public class MessageWithLists
+    {
+        public List<bool> Bools { get; set; }
+        public List<byte> Bytes { get; set; }
+        public List<char> Chars { get; set; }
+        public List<decimal> Decimals { get; set; }
+        public List<double> Doubles { get; set; }
+        public List<DateTimeStyles> Enums { get; set; }
+        public List<float> Floats { get; set; }
+        public List<int> Ints { get; set; }
+        public List<long> Longs { get; set; }
+        public List<sbyte> SBytes { get; set; }
+        public List<short> Shorts { get; set; }
+        public List<uint> UInts { get; set; }
+        public List<ulong> ULongs { get; set; }
+        public List<ushort> UShorts { get; set; }
+        public List<string> Strings { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/Person.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/Person.cs
@@ -1,0 +1,11 @@
+﻿namespace Common.Tests.TestCases.Types
+{
+    using System;
+
+    [Serializable]
+    public class Person
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/PolymorphicCollection.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/PolymorphicCollection.cs
@@ -1,0 +1,53 @@
+﻿namespace Common.Tests.TestCases.Types
+{
+    using System;
+    using System.Collections.Generic;
+
+    [Serializable]
+    public class PolymorphicCollection
+    {
+        public List<BaseEntity> Items { get; set; }
+    }
+
+    [Serializable]
+    public class BaseEntity
+    {
+        public virtual string Name { get; set; }
+    }
+
+    [Serializable]
+    public class SpecializationA : BaseEntity
+    {
+        public override string Name { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = (SpecializationA)obj;
+
+            return other != null && Name == other.Name;
+        }
+
+        public override int GetHashCode()
+        {
+            return Name?.GetHashCode() ?? 0;
+        }
+    }
+
+    [Serializable]
+    public class SpecializationB : BaseEntity
+    {
+        public override string Name { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = (SpecializationB)obj;
+
+            return other != null && Name == other.Name;
+        }
+
+        public override int GetHashCode()
+        {
+            return Name?.GetHashCode() ?? 0;
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/TestMessageWithChar.cs
+++ b/src/SerializerCompatibilityTests/Common/Tests/TestCases/Types/TestMessageWithChar.cs
@@ -1,0 +1,11 @@
+﻿namespace Common.Tests.TestCases.Types
+{
+    using System;
+
+    [Serializable]
+    public class TestMessageWithChar
+    {
+        public char InvalidCharacter { get; set; }
+        public char ValidCharacter { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/Common/app.config
+++ b/src/SerializerCompatibilityTests/Common/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/SerializerCompatibilityTests/Common/packages.config
+++ b/src/SerializerCompatibilityTests/Common/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="Paket.Core" version="2.5.0" allowedVersions="[2.5.0]" targetFramework="net452" />
+</packages>

--- a/src/SerializerCompatibilityTests/NServiceBus3/JsonSerializerFacade.cs
+++ b/src/SerializerCompatibilityTests/NServiceBus3/JsonSerializerFacade.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Common;
+using NServiceBus;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.ObjectBuilder;
+using NServiceBus.Serializers.Json;
+
+class JsonSerializerFacade : ISerializerFacade
+{
+    public JsonSerializerFacade(params Type[] objectTypes)
+    {
+        mapper = new MessageMapper();
+        serializer = new JsonMessageSerializer(mapper);
+
+        SetupTypeHeader(objectTypes);
+    }
+
+    public void Serialize(Stream stream, object instance)
+    {
+        serializer.Serialize(new[]
+        {
+            instance
+        }, stream);
+    }
+
+    public object[] Deserialize(Stream stream)
+    {
+        return serializer.Deserialize(stream);
+    }
+
+    public object CreateInstance(Type type)
+    {
+        return type.IsInterface ? mapper.CreateInstance(type) : Activator.CreateInstance(type);
+    }
+
+    void SetupTypeHeader(Type[] objectTypes)
+    {
+        Debug.WriteLine("xxx");
+        AppDomain.CurrentDomain.GetAssemblies().Where(a => a.IsDynamic == false).ToList().ForEach(a => Debug.WriteLine(a.CodeBase));
+
+        Configure.With();
+        Configure.Instance.Builder = new FakeBuilder
+        {
+            Bus = new FakeBus
+            {
+                CurrentMessageContext = new FakeMessageContext
+                {
+                    Headers = headers
+                }
+            }
+        };
+
+        headers[typeHeaderName] = string.Join(";", objectTypes.Select(ot => ot.AssemblyQualifiedName).ToArray());
+
+        mapper.Initialize(objectTypes);
+    }
+
+    MessageMapper mapper;
+    JsonMessageSerializer serializer;
+
+    Dictionary<string, string> headers = new Dictionary<string, string>();
+    string typeHeaderName = "NServiceBus.EnclosedMessageTypes";
+
+    class FakeBuilder : IBuilder
+    {
+        public IBus Bus { get; set; }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Build(Type typeToBuild)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IBuilder CreateChildBuilder()
+        {
+            throw new NotImplementedException();
+        }
+
+        public T Build<T>()
+        {
+            return (T)Bus;
+        }
+
+        public IEnumerable<T> BuildAll<T>()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<object> BuildAll(Type typeToBuild)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void BuildAndDispatch(Type typeToBuild, Action<object> action)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    class FakeBus : IBus
+    {
+        public T CreateInstance<T>()
+        {
+            throw new NotImplementedException();
+        }
+
+        public T CreateInstance<T>(Action<T> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object CreateInstance(Type messageType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Publish<T>(params T[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Publish<T>(Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Subscribe(Type messageType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Subscribe<T>()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Subscribe(Type messageType, Predicate<object> condition)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Subscribe<T>(Predicate<T> condition)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Unsubscribe(Type messageType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Unsubscribe<T>()
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback SendLocal(params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback SendLocal<T>(Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send(params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send<T>(Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send(string destination, params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send(Address address, params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send<T>(string destination, Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send<T>(Address address, Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send(string destination, string correlationId, params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send(Address address, string correlationId, params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send<T>(string destination, string correlationId, Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Send<T>(Address address, string correlationId, Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback SendToSites(IEnumerable<string> siteKeys, params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Defer(TimeSpan delay, params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICallback Defer(DateTime processAt, params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Reply(params object[] messages)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Reply<T>(Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Return<T>(T errorEnum)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleCurrentMessageLater()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ForwardCurrentMessageTo(string destination)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void DoNotContinueDispatchingCurrentMessageToHandlers()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDictionary<string, string> OutgoingHeaders { get; }
+        public IMessageContext CurrentMessageContext { get; set; }
+    }
+
+    class FakeMessageContext : IMessageContext
+    {
+        public string Id { get; }
+        public string ReturnAddress { get; }
+        public Address ReplyToAddress { get; }
+        public DateTime TimeSent { get; }
+        public IDictionary<string, string> Headers { get; set; }
+    }
+}

--- a/src/SerializerCompatibilityTests/NServiceBus3/NServiceBus3.csproj
+++ b/src/SerializerCompatibilityTests/NServiceBus3/NServiceBus3.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{17FD8B87-AB4D-4663-8C9F-A3B1213D046D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NServiceBus3</RootNamespace>
+    <AssemblyName>NServiceBus3</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\NServiceBus3\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\Release\NServiceBus3\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus, Version=3.3.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.Interfaces.3.3.15\lib\net40\NServiceBus.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.3.3.15\lib\net40\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Tester.cs">
+      <Link>Tester.cs</Link>
+    </Compile>
+    <Compile Include="JsonSerializerFacade.cs" />
+    <Compile Include="XmlSerializerFacade.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj">
+      <Project>{572499ED-E234-4C66-BD6E-D5A845065C5F}</Project>
+      <Name>Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/SerializerCompatibilityTests/NServiceBus3/NServiceBus3.csproj.DotSettings
+++ b/src/SerializerCompatibilityTests/NServiceBus3/NServiceBus3.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>

--- a/src/SerializerCompatibilityTests/NServiceBus3/XmlSerializerFacade.cs
+++ b/src/SerializerCompatibilityTests/NServiceBus3/XmlSerializerFacade.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using Common;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Serializers.XML;
+
+class XmlSerializerFacade : ISerializerFacade
+{
+    public XmlSerializerFacade(params Type[] objectTypes)
+    {
+        mapper = new MessageMapper();
+        serializer = new XmlMessageSerializer(mapper);
+        mapper.Initialize(objectTypes);
+        serializer.Initialize(objectTypes);
+    }
+
+    public void Serialize(Stream stream, object instance)
+    {
+        serializer.Serialize(new[]
+        {
+            instance
+        }, stream);
+    }
+
+    public object[] Deserialize(Stream stream)
+    {
+        return serializer.Deserialize(stream);
+    }
+
+    public object CreateInstance(Type type)
+    {
+        return type.IsInterface ? mapper.CreateInstance(type) : Activator.CreateInstance(type);
+    }
+
+    readonly XmlMessageSerializer serializer;
+    readonly MessageMapper mapper;
+}

--- a/src/SerializerCompatibilityTests/NServiceBus3/app.config
+++ b/src/SerializerCompatibilityTests/NServiceBus3/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/SerializerCompatibilityTests/NServiceBus3/packages.config
+++ b/src/SerializerCompatibilityTests/NServiceBus3/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="log4net" version="1.2.10" targetFramework="net45" />
+  <package id="NServiceBus" version="3.3.15" targetFramework="net45" />
+  <package id="NServiceBus.Interfaces" version="3.3.15" targetFramework="net45" />
+</packages>

--- a/src/SerializerCompatibilityTests/NServiceBus4/JsonSerializerFacade.cs
+++ b/src/SerializerCompatibilityTests/NServiceBus4/JsonSerializerFacade.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using Common;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Serializers.Json;
+
+class JsonSerializerFacade : ISerializerFacade
+{
+    public JsonSerializerFacade(params Type[] objectTypes)
+    {
+        this.objectTypes = objectTypes;
+        mapper = new MessageMapper();
+        serializer = new JsonMessageSerializer(mapper);
+        mapper.Initialize(objectTypes);
+    }
+
+    public void Serialize(Stream stream, object instance)
+    {
+        serializer.Serialize(new[]
+        {
+            instance
+        }, stream);
+    }
+
+    public object[] Deserialize(Stream stream)
+    {
+        return serializer.Deserialize(stream, objectTypes);
+    }
+
+    public object CreateInstance(Type type)
+    {
+        return type.IsInterface ? mapper.CreateInstance(type) : Activator.CreateInstance(type);
+    }
+
+    MessageMapper mapper;
+    JsonMessageSerializer serializer;
+    Type[] objectTypes;
+}

--- a/src/SerializerCompatibilityTests/NServiceBus4/NServiceBus4.csproj
+++ b/src/SerializerCompatibilityTests/NServiceBus4/NServiceBus4.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2428412D-C9C5-4006-BFC4-DF7CCB90B12E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NServiceBus4</RootNamespace>
+    <AssemblyName>NServiceBus4</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\NServiceBus4\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\Release\NServiceBus4\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NServiceBus, Version=4.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.Interfaces.4.0.10\lib\net40\NServiceBus.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.4.0.10\lib\net40\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Tester.cs">
+      <Link>Tester.cs</Link>
+    </Compile>
+    <Compile Include="JsonSerializerFacade.cs" />
+    <Compile Include="XmlSerializerFacade.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj">
+      <Project>{572499ED-E234-4C66-BD6E-D5A845065C5F}</Project>
+      <Name>Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/SerializerCompatibilityTests/NServiceBus4/NServiceBus4.csproj.DotSettings
+++ b/src/SerializerCompatibilityTests/NServiceBus4/NServiceBus4.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>

--- a/src/SerializerCompatibilityTests/NServiceBus4/XmlSerializerFacade.cs
+++ b/src/SerializerCompatibilityTests/NServiceBus4/XmlSerializerFacade.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using Common;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Serializers.XML;
+
+class XmlSerializerFacade : ISerializerFacade
+{
+    public XmlSerializerFacade(params Type[] objectTypes)
+    {
+        mapper = new MessageMapper();
+        serializer = new XmlMessageSerializer(mapper);
+        mapper.Initialize(objectTypes);
+        serializer.Initialize(objectTypes);
+    }
+
+    public void Serialize(Stream stream, object instance)
+    {
+        serializer.Serialize(new[]
+        {
+            instance
+        }, stream);
+    }
+
+    public object[] Deserialize(Stream stream)
+    {
+        return serializer.Deserialize(stream, null);
+    }
+
+    public object CreateInstance(Type type)
+    {
+        return type.IsInterface ? mapper.CreateInstance(type) : Activator.CreateInstance(type);
+    }
+
+    readonly XmlMessageSerializer serializer;
+    readonly MessageMapper mapper;
+}

--- a/src/SerializerCompatibilityTests/NServiceBus4/app.config
+++ b/src/SerializerCompatibilityTests/NServiceBus4/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/SerializerCompatibilityTests/NServiceBus4/packages.config
+++ b/src/SerializerCompatibilityTests/NServiceBus4/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NServiceBus" version="4.0.10" targetFramework="net45" />
+  <package id="NServiceBus.Interfaces" version="4.0.10" targetFramework="net45" />
+</packages>

--- a/src/SerializerCompatibilityTests/NServiceBus5/JsonSerializerFacade.cs
+++ b/src/SerializerCompatibilityTests/NServiceBus5/JsonSerializerFacade.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using Common;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Serializers.Json;
+
+class JsonSerializerFacade : ISerializerFacade
+{
+    public JsonSerializerFacade(params Type[] objectTypes)
+    {
+        this.objectTypes = objectTypes;
+        mapper = new MessageMapper();
+        serializer = new JsonMessageSerializer(mapper);
+        mapper.Initialize(objectTypes);
+    }
+
+    public void Serialize(Stream stream, object instance)
+    {
+        serializer.Serialize(instance, stream);
+    }
+
+    public object[] Deserialize(Stream stream)
+    {
+        return serializer.Deserialize(stream, objectTypes);
+    }
+
+    public object CreateInstance(Type type)
+    {
+        return type.IsInterface ? mapper.CreateInstance(type) : Activator.CreateInstance(type);
+    }
+
+    MessageMapper mapper;
+    JsonMessageSerializer serializer;
+    Type[] objectTypes;
+}
+
+/*
+    public static void TestDeserializationIssue()
+    {
+        var serializer = new JsonMessageSerializer(new MessageMapper());
+
+        var fileInfo = new FileInfo(@"C:\git\Particular\ProductionTests\src\SerializerCompatibilityTests\bin\Debug\SerializationCompatibilityFiles\NServiceBus 5.0.6_TestPolimorficCollections_.json");
+
+        using (var fileStream = fileInfo.OpenRead())
+        {
+            var instance = serializer.Deserialize(fileStream, new[]
+            {
+                typeof(PolymorphicCollection)
+            }).First();
+
+        }
+    }
+    */

--- a/src/SerializerCompatibilityTests/NServiceBus5/NServiceBus5.csproj
+++ b/src/SerializerCompatibilityTests/NServiceBus5/NServiceBus5.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BE2C7B5E-7A71-4B0C-9020-343ED2010993}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NServiceBus5</RootNamespace>
+    <AssemblyName>NServiceBus5</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\NServiceBus5\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\Release\NServiceBus5\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>
+    </StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.5.2.5\lib\net45\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Tester.cs">
+      <Link>Tester.cs</Link>
+    </Compile>
+    <Compile Include="JsonSerializerFacade.cs" />
+    <Compile Include="XmlSerializerFacade.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj">
+      <Project>{572499ED-E234-4C66-BD6E-D5A845065C5F}</Project>
+      <Name>Common</Name>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/SerializerCompatibilityTests/NServiceBus5/NServiceBus5.csproj.DotSettings
+++ b/src/SerializerCompatibilityTests/NServiceBus5/NServiceBus5.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>

--- a/src/SerializerCompatibilityTests/NServiceBus5/XmlSerializerFacade.cs
+++ b/src/SerializerCompatibilityTests/NServiceBus5/XmlSerializerFacade.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.IO;
+using Common;
+using NServiceBus;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Serializers.XML;
+
+class XmlSerializerFacade : ISerializerFacade
+{
+    public XmlSerializerFacade(params Type[] objectTypes)
+    {
+        mapper = new MessageMapper();
+        serializer = new XmlMessageSerializer(mapper, new Conventions());
+        mapper.Initialize(objectTypes);
+        serializer.Initialize(objectTypes);
+    }
+
+    public void Serialize(Stream stream, object instance)
+    {
+        serializer.Serialize(instance, stream);
+    }
+
+    public object[] Deserialize(Stream stream)
+    {
+        return serializer.Deserialize(stream);
+    }
+
+    public object CreateInstance(Type type)
+    {
+        return type.IsInterface ? mapper.CreateInstance(type) : Activator.CreateInstance(type);
+    }
+
+    readonly XmlMessageSerializer serializer;
+    readonly MessageMapper mapper;
+}

--- a/src/SerializerCompatibilityTests/NServiceBus5/app.config
+++ b/src/SerializerCompatibilityTests/NServiceBus5/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/SerializerCompatibilityTests/NServiceBus5/packages.config
+++ b/src/SerializerCompatibilityTests/NServiceBus5/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NServiceBus" version="5.2.5" targetFramework="net45" />
+</packages>

--- a/src/SerializerCompatibilityTests/NServiceBus6/JsonSerializerFacade.cs
+++ b/src/SerializerCompatibilityTests/NServiceBus6/JsonSerializerFacade.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using Common;
+using NServiceBus;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Serialization;
+using NServiceBus.Settings;
+
+class JsonSerializerFacade : ISerializerFacade
+{
+    public JsonSerializerFacade(params Type[] objectTypes)
+    {
+        this.objectTypes = objectTypes;
+        mapper = new MessageMapper();
+        var settings = new SettingsHolder();
+        serializer = new JsonSerializer().Configure(settings)(mapper);
+        mapper.Initialize(objectTypes);
+    }
+
+    public void Serialize(Stream stream, object instance)
+    {
+        serializer.Serialize(new[]
+        {
+            instance
+        }, stream);
+    }
+
+    public object[] Deserialize(Stream stream)
+    {
+        return serializer.Deserialize(stream, objectTypes);
+    }
+
+    public object CreateInstance(Type type)
+    {
+        return type.IsInterface ? mapper.CreateInstance(type) : Activator.CreateInstance(type);
+    }
+
+    MessageMapper mapper;
+    IMessageSerializer serializer;
+    Type[] objectTypes;
+}

--- a/src/SerializerCompatibilityTests/NServiceBus6/NServiceBus6.csproj
+++ b/src/SerializerCompatibilityTests/NServiceBus6/NServiceBus6.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{10D11044-C92C-42AD-830E-57012FF4F039}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NServiceBus6</RootNamespace>
+    <AssemblyName>NServiceBus6</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\NServiceBus6\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\Release\NServiceBus6\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.6.0.0-unstable1753\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj">
+      <Project>{572499ED-E234-4C66-BD6E-D5A845065C5F}</Project>
+      <Name>Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Tester.cs">
+      <Link>Tester.cs</Link>
+    </Compile>
+    <Compile Include="JsonSerializerFacade.cs" />
+    <Compile Include="XmlSerializerFacade.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/SerializerCompatibilityTests/NServiceBus6/NServiceBus6.csproj.DotSettings
+++ b/src/SerializerCompatibilityTests/NServiceBus6/NServiceBus6.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>

--- a/src/SerializerCompatibilityTests/NServiceBus6/XmlSerializerFacade.cs
+++ b/src/SerializerCompatibilityTests/NServiceBus6/XmlSerializerFacade.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using Common;
+using NServiceBus;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Serialization;
+using NServiceBus.Settings;
+
+class XmlSerializerFacade : ISerializerFacade
+{
+    public XmlSerializerFacade(params Type[] objectTypes)
+    {
+        mapper = new MessageMapper();
+        var settings = new SettingsHolder();
+        var conventions = CreateTestConventions(settings);
+        settings.Set<Conventions>(conventions);
+        settings.Set("TypesToScan", objectTypes);
+
+        serializer = new XmlSerializer().Configure(settings)(mapper);
+        mapper.Initialize(objectTypes);
+    }
+
+
+    public void Serialize(Stream stream, object instance)
+    {
+        serializer.Serialize(instance, stream);
+    }
+
+    public object[] Deserialize(Stream stream)
+    {
+        return serializer.Deserialize(stream);
+    }
+
+    public object CreateInstance(Type type)
+    {
+        return type.IsInterface ? mapper.CreateInstance(type) : Activator.CreateInstance(type);
+    }
+
+    object CreateTestConventions(SettingsHolder settings)
+    {
+        var builder = new ConventionsBuilder(settings);
+        builder.DefiningMessagesAs(type => type.FullName.Contains("TestCases"));
+        return builder.Conventions;
+    }
+
+    IMessageSerializer serializer;
+    MessageMapper mapper;
+}

--- a/src/SerializerCompatibilityTests/NServiceBus6/app.config
+++ b/src/SerializerCompatibilityTests/NServiceBus6/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/SerializerCompatibilityTests/NServiceBus6/packages.config
+++ b/src/SerializerCompatibilityTests/NServiceBus6/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NServiceBus" version="6.0.0-unstable1753" targetFramework="net452" />
+</packages>

--- a/src/SerializerCompatibilityTests/SerializerCompatibilityTests.sln
+++ b/src/SerializerCompatibilityTests/SerializerCompatibilityTests.sln
@@ -1,0 +1,58 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus3", "NServiceBus3\NServiceBus3.csproj", "{17FD8B87-AB4D-4663-8C9F-A3B1213D046D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Common\Common.csproj", "{572499ED-E234-4C66-BD6E-D5A845065C5F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus4", "NServiceBus4\NServiceBus4.csproj", "{2428412D-C9C5-4006-BFC4-DF7CCB90B12E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus5", "NServiceBus5\NServiceBus5.csproj", "{BE2C7B5E-7A71-4B0C-9020-343ED2010993}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus6", "NServiceBus6\NServiceBus6.csproj", "{10D11044-C92C-42AD-830E-57012FF4F039}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{FEAAE402-8ED0-47FB-8E54-42B1D7F654CC}"
+	ProjectSection(ProjectDependencies) = postProject
+		{2428412D-C9C5-4006-BFC4-DF7CCB90B12E} = {2428412D-C9C5-4006-BFC4-DF7CCB90B12E}
+		{10D11044-C92C-42AD-830E-57012FF4F039} = {10D11044-C92C-42AD-830E-57012FF4F039}
+		{BE2C7B5E-7A71-4B0C-9020-343ED2010993} = {BE2C7B5E-7A71-4B0C-9020-343ED2010993}
+		{17FD8B87-AB4D-4663-8C9F-A3B1213D046D} = {17FD8B87-AB4D-4663-8C9F-A3B1213D046D}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{17FD8B87-AB4D-4663-8C9F-A3B1213D046D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17FD8B87-AB4D-4663-8C9F-A3B1213D046D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17FD8B87-AB4D-4663-8C9F-A3B1213D046D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17FD8B87-AB4D-4663-8C9F-A3B1213D046D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{572499ED-E234-4C66-BD6E-D5A845065C5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{572499ED-E234-4C66-BD6E-D5A845065C5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{572499ED-E234-4C66-BD6E-D5A845065C5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{572499ED-E234-4C66-BD6E-D5A845065C5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2428412D-C9C5-4006-BFC4-DF7CCB90B12E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2428412D-C9C5-4006-BFC4-DF7CCB90B12E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2428412D-C9C5-4006-BFC4-DF7CCB90B12E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2428412D-C9C5-4006-BFC4-DF7CCB90B12E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE2C7B5E-7A71-4B0C-9020-343ED2010993}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE2C7B5E-7A71-4B0C-9020-343ED2010993}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE2C7B5E-7A71-4B0C-9020-343ED2010993}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE2C7B5E-7A71-4B0C-9020-343ED2010993}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10D11044-C92C-42AD-830E-57012FF4F039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10D11044-C92C-42AD-830E-57012FF4F039}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10D11044-C92C-42AD-830E-57012FF4F039}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10D11044-C92C-42AD-830E-57012FF4F039}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FEAAE402-8ED0-47FB-8E54-42B1D7F654CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FEAAE402-8ED0-47FB-8E54-42B1D7F654CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FEAAE402-8ED0-47FB-8E54-42B1D7F654CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FEAAE402-8ED0-47FB-8E54-42B1D7F654CC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/SerializerCompatibilityTests/SerializerCompatibilityTests.sln.DotSettings
+++ b/src/SerializerCompatibilityTests/SerializerCompatibilityTests.sln.DotSettings
@@ -1,0 +1,601 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
+	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/AutoCompleteBasicCompletion/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/IntelliSenseCompletingCharactersSettingCSharp/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/LookupWindow/ShowSummary/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeEditing/Localization/CSharpLocalizationOptions/DontAnalyseVerbatimStrings/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeModifiers/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AssignToImplicitGlobalInFunctionScope/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BaseObjectEqualsIsObjectEquals/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassWithVirtualMembersNeverInherited_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CommentTypo/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CompareNonConstrainedGenericWithNull/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConditionalTernaryEqualBranch/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConditionIsAlwaysTrueOrFalse/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConstantNullCoalescingCondition/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConstructorInitializerLoop/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertConditionalTernaryToNullCoalescing/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfStatementToConditionalTernaryExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfStatementToNullCoalescingExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS0108/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS0109/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS0162/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1570/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1571/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1573/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1574/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1580/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1584/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1587/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1589/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1710/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=DoubleNegationOperator/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyConstructor/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyDestructor/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyForStatement/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyGeneralCatchClause/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyNamespace/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyStatement/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EventNeverInvoked/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ExpressionIsAlwaysNull/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FieldCanBeMadeReadOnly_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FieldCanBeMadeReadOnly_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=HeuristicUnreachableCode/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=LocalizableElement/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MultipleOrderBy/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NotAccessedField_002EGlobal/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NotAccessedVariable/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NotAccessedVariable_002ECompiler/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialMethodWithSinglePart/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleIntendedRethrow/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMistakenCallToGetType_002E1/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMistakenCallToGetType_002E2/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleNullReferenceException/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PrivateFieldCanBeConvertedToLocalVariable/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAssignment/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBaseConstructorCall/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBoolCompare/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCast_002E0/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCatchClause/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCollectionInitializerElementBraces/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCommaInArrayInitializer/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCommaInInitializer/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantDefaultFieldInitializer/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantEmptyDefaultSwitchBranch/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantEmptyFinallyBlock/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantEmptyObjectOrCollectionInitializer/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantEnumerableCastCall/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantExplicitArrayCreation/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantExtendsListEntry/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantIfElseBlock/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantLambdaParameterType/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantLambdaSignatureParentheses/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNameQualifier/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantStringFormatCall/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantStringInterpolation/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantStringToCharArrayCall/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantThisQualifier/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantToStringCall/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantTypeArgumentsOfMethod/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FormatStringProblem/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=IteratorMethodResultIsIgnored/@EntryIndexedValue">WARNING</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NotAccessedField_002ELocal/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBaseQualifier/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCast/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ClassCanBeSealed_002EGlobal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ClassCanBeSealed_002ELocal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ConvertIfStatementToReturnStatement_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ConvertIfStatementToSwitchStatement_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ConvertToAutoPropertyWithPrivateSetter_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022InvertIf_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022LoopCanBePartlyConvertedToQuery_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022MemberCanBeInternal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022MemberCanBeMadeStatic_002EGlobal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022MemberCanBeMadeStatic_002ELocal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022RedundantArgumentNameForLiteralExpression_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022RedundantToStringCallForValueType_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022SimilarAnonymousTypeNearby_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022SuggestBaseTypeForParameter_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022SuggestUseVarKeywordEverywhere_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022TryStatementsCanBeMerged_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022UnknownCssVendorExtension_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CStaticSeverity_0020Severity_003D_00222_0022_0020Title_003D_0022Structural_0020Search_0020Hints_0022_0020GroupId_003D_0022StructuralSearch_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SealedMemberInSealedClass/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StaticFieldInGenericType/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEverywhere/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEvident/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FBuiltInTypes/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FElsewhere/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FSimpleTypes/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ThreadStaticAtInstanceField/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=TooWideLocalVariableScope/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnassignedField_002ECompiler/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnassignedField_002ELocal/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnreachableCode/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedField_002ECompiler/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedLabel/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002ELocal/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002EGlobal/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002ELocal/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedVariable/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseObjectOrCollectionInitializer/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseStringInterpolation/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ValueParameterNotUsed/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VBPossibleMistakenCallToGetType_002E1/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VBPossibleMistakenCallToGetType_002E2/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=Format_0020My_0020Code_0020Using_0020_0022Particular_0022_0020conventions/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="Format My Code Using &amp;quot;Particular&amp;quot; conventions"&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSUseVar&gt;&lt;BehavourStyle&gt;CAN_CHANGE_TO_IMPLICIT&lt;/BehavourStyle&gt;&lt;LocalVariableStyle&gt;ALWAYS_IMPLICIT&lt;/LocalVariableStyle&gt;&lt;ForeachVariableStyle&gt;ALWAYS_IMPLICIT&lt;/ForeachVariableStyle&gt;&lt;/CSUseVar&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;JsInsertSemicolon&gt;True&lt;/JsInsertSemicolon&gt;&lt;JsReformatCode&gt;True&lt;/JsReformatCode&gt;&lt;CssReformatCode&gt;True&lt;/CssReformatCode&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;CssAlphabetizeProperties&gt;True&lt;/CssAlphabetizeProperties&gt;&lt;/Profile&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">Default: Reformat Code</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">Format My Code Using "Particular" conventions</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_INTERNAL_MODIFIER/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_PRIVATE_MODIFIER/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOR_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOREACH_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_IFELSE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_FIXED_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_SIZEOF_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_TYPEOF_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_MULTIPLE_TYPE_PARAMEER_CONSTRAINTS_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_OBJECT_AND_COLLECTION_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/JavaScriptFormatOther/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/IndentSubtags/@EntryValue">ZeroIndent</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/IndentTagContent/@EntryValue">ZeroIndent</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
+&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+  &lt;TypePattern DisplayName="COM interfaces or structs"&gt;&#xD;
+    &lt;TypePattern.Match&gt;&#xD;
+      &lt;Or&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Interface" /&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute Name="System.Runtime.InteropServices.InterfaceTypeAttribute" /&gt;&#xD;
+            &lt;HasAttribute Name="System.Runtime.InteropServices.ComImport" /&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+        &lt;Kind Is="Struct" /&gt;&#xD;
+      &lt;/Or&gt;&#xD;
+    &lt;/TypePattern.Match&gt;&#xD;
+  &lt;/TypePattern&gt;&#xD;
+  &lt;TypePattern DisplayName="NUnit Test Fixtures" RemoveRegions="All"&gt;&#xD;
+    &lt;TypePattern.Match&gt;&#xD;
+      &lt;And&gt;&#xD;
+        &lt;Kind Is="Class" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestFixtureAttribute" Inherited="True" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestCaseFixtureAttribute" Inherited="True" /&gt;&#xD;
+      &lt;/And&gt;&#xD;
+    &lt;/TypePattern.Match&gt;&#xD;
+    &lt;Entry DisplayName="Setup/Teardown Methods"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Method" /&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.SetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.TearDownAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureSetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureTearDownAttribute" Inherited="True" /&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry DisplayName="Test Methods" Priority="100"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Method" /&gt;&#xD;
+          &lt;HasAttribute Name="NUnit.Framework.TestAttribute" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/TypePattern&gt;&#xD;
+  &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
+    &lt;Entry DisplayName="Public Delegates" Priority="100"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Access Is="Public" /&gt;&#xD;
+          &lt;Kind Is="Delegate" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Public Enums" Priority="100"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Access Is="Public" /&gt;&#xD;
+          &lt;Kind Is="Enum" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Constructors"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Kind Is="Constructor" /&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Static /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="Property" /&gt;&#xD;
+          &lt;Kind Is="Indexer" /&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Interface Implementations" Priority="100"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Member" /&gt;&#xD;
+          &lt;ImplementsInterface /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;ImplementsInterface Immediate="True" /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry DisplayName="Fields"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Field" /&gt;&#xD;
+          &lt;Not&gt;&#xD;
+            &lt;Static /&gt;&#xD;
+          &lt;/Not&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Access /&gt;&#xD;
+        &lt;Readonly /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Static Fields and Constants"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="Constant" /&gt;&#xD;
+          &lt;And&gt;&#xD;
+            &lt;Kind Is="Field" /&gt;&#xD;
+            &lt;Static /&gt;&#xD;
+          &lt;/And&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Kind Order="Constant Field" /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Nested Types"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Kind Is="Type" /&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/TypePattern&gt;&#xD;
+&lt;/Patterns&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/CustomPattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-8" ?&gt;&#xD;
+&#xD;
+&lt;!--&#xD;
+I. Overall&#xD;
+&#xD;
+I.1 Each pattern can have &lt;Match&gt;....&lt;/Match&gt; element. For the given type declaration, the pattern with the match, evaluated to 'true' with the largest weight, will be used &#xD;
+I.2 Each pattern consists of the sequence of &lt;Entry&gt;...&lt;/Entry&gt; elements. Type member declarations are distributed between entries&#xD;
+I.3 If pattern has RemoveAllRegions="true" attribute, then all regions will be cleared prior to reordering. Otherwise, only auto-generated regions will be cleared&#xD;
+I.4 The contents of each entry is sorted by given keys (First key is primary,  next key is secondary, etc). Then the declarations are grouped and en-regioned by given property&#xD;
+&#xD;
+II. Available match operands&#xD;
+&#xD;
+Each operand may have Weight="..." attribute. This weight will be added to the match weight if the operand is evaluated to 'true'.&#xD;
+The default weight is 1&#xD;
+&#xD;
+II.1 Boolean functions:&#xD;
+II.1.1 &lt;And&gt;....&lt;/And&gt;&#xD;
+II.1.2 &lt;Or&gt;....&lt;/Or&gt;&#xD;
+II.1.3 &lt;Not&gt;....&lt;/Not&gt;&#xD;
+&#xD;
+II.2 Operands&#xD;
+II.2.1 &lt;Kind Is="..."/&gt;. Kinds are: class, struct, interface, enum, delegate, type, constructor, destructor, property, indexer, method, operator, field, constant, event, member&#xD;
+II.2.2 &lt;Name Is="..." [IgnoreCase="true/false"] /&gt;. The 'Is' attribute contains regular expression&#xD;
+II.2.3 &lt;HasAttribute CLRName="..." [Inherit="true/false"] /&gt;. The 'CLRName' attribute contains regular expression&#xD;
+II.2.4 &lt;Access Is="..."/&gt;. The 'Is' values are: public, protected, internal, protected internal, private&#xD;
+II.2.5 &lt;Static/&gt;&#xD;
+II.2.6 &lt;Abstract/&gt;&#xD;
+II.2.7 &lt;Virtual/&gt;&#xD;
+II.2.8 &lt;Override/&gt;&#xD;
+II.2.9 &lt;Sealed/&gt;&#xD;
+II.2.10 &lt;Readonly/&gt;&#xD;
+II.2.11 &lt;ImplementsInterface CLRName="..."/&gt;. The 'CLRName' attribute contains regular expression&#xD;
+II.2.12 &lt;HandlesEvent /&gt;&#xD;
+--&gt;&#xD;
+&#xD;
+&lt;Patterns xmlns="urn:shemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+&#xD;
+  &lt;!--Do not reorder COM interfaces and structs marked by StructLayout attribute--&gt;&#xD;
+  &lt;Pattern&gt;&#xD;
+    &lt;Match&gt;&#xD;
+      &lt;Or Weight="100"&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="interface"/&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute CLRName="System.Runtime.InteropServices.InterfaceTypeAttribute"/&gt;&#xD;
+            &lt;HasAttribute CLRName="System.Runtime.InteropServices.ComImport"/&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+        &lt;HasAttribute CLRName="System.Runtime.InteropServices.StructLayoutAttribute"/&gt;&#xD;
+      &lt;/Or&gt;&#xD;
+    &lt;/Match&gt;&#xD;
+  &lt;/Pattern&gt;&#xD;
+&#xD;
+  &lt;!--Special formatting of NUnit test fixture--&gt;&#xD;
+  &lt;Pattern RemoveAllRegions="true"&gt;&#xD;
+    &lt;Match&gt;&#xD;
+      &lt;And Weight="100"&gt;&#xD;
+        &lt;Kind Is="class"/&gt;&#xD;
+        &lt;HasAttribute CLRName="NUnit.Framework.TestFixtureAttribute" Inherit="true"/&gt;&#xD;
+      &lt;/And&gt;&#xD;
+    &lt;/Match&gt;&#xD;
+&#xD;
+    &lt;!--Setup/Teardow--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="method"/&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute CLRName="NUnit.Framework.SetUpAttribute" Inherit="true"/&gt;&#xD;
+            &lt;HasAttribute CLRName="NUnit.Framework.TearDownAttribute" Inherit="true"/&gt;&#xD;
+            &lt;HasAttribute CLRName="NUnit.Framework.FixtureSetUpAttribute" Inherit="true"/&gt;&#xD;
+            &lt;HasAttribute CLRName="NUnit.Framework.FixtureTearDownAttribute" Inherit="true"/&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--All other members--&gt;&#xD;
+    &lt;Entry/&gt;&#xD;
+    &#xD;
+    &lt;!--Test methods--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And Weight="100"&gt;&#xD;
+          &lt;Kind Is="method"/&gt;&#xD;
+          &lt;HasAttribute CLRName="NUnit.Framework.TestAttribute" Inherit="false"/&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/Pattern&gt;&#xD;
+&#xD;
+  &lt;!--Default pattern--&gt;&#xD;
+  &lt;Pattern&gt;&#xD;
+&#xD;
+    &lt;!--public delegate--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And Weight="100"&gt;&#xD;
+          &lt;Access Is="public"/&gt;&#xD;
+          &lt;Kind Is="delegate"/&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--public enum--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And Weight="100"&gt;&#xD;
+          &lt;Access Is="public"/&gt;&#xD;
+          &lt;Kind Is="enum"/&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+&#xD;
+    &lt;!--Constructors. Place static one first--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;Kind Is="constructor"/&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Static/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--properties, indexers--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="property"/&gt;&#xD;
+          &lt;Kind Is="indexer"/&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--interface implementations--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And Weight="100"&gt;&#xD;
+          &lt;Kind Is="member"/&gt;&#xD;
+          &lt;ImplementsInterface/&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;ImplementsInterface Immediate="true"/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--all other members--&gt;&#xD;
+    &lt;Entry/&gt;&#xD;
+    &#xD;
+&lt;!--static fields and constants--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="constant"/&gt;&#xD;
+          &lt;And&gt;&#xD;
+            &lt;Kind Is="field"/&gt;&#xD;
+            &lt;Static/&gt;&#xD;
+          &lt;/And&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Kind Order="constant field"/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--instance fields--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="field"/&gt;&#xD;
+          &lt;Not&gt;&#xD;
+            &lt;Static/&gt;&#xD;
+          &lt;/Not&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Readonly/&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+&#xD;
+    &lt;!--nested types--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;Kind Is="type"/&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/Pattern&gt;&#xD;
+  &#xD;
+&lt;/Patterns&gt;&#xD;
+</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/LayoutType/@EntryValue">CustomLayout</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/QualifiedUsingAtNestedScope/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Constructor/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Constructor/Options/=XmlDocumentation/@EntryIndexedValue">False</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Equality/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Equality/Options/=EqualityOperators/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Equality/Options/=ImplementIEquatable/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Equality/Options/=XmlDocumentation/@EntryIndexedValue">False</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Global/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Global/Options/=PropertyBody/@EntryIndexedValue">Automatic property</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Implementations/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Implementations/Options/=WrapInRegion/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Implementations/Options/=XmlDocumentation/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DB/@EntryIndexedValue">DB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DTC/@EntryIndexedValue">DTC</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NSB/@EntryIndexedValue">NSB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SLA/@EntryIndexedValue">SLA</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Interfaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=LocalConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Locals/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=MethodPropertyEvent/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Other/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Parameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FBLOCK_005FSCOPE_005FCONSTANT/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FBLOCK_005FSCOPE_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FCONSTRUCTOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FGLOBAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLABEL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLOCAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FOBJECT_005FPROPERTY_005FOF_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FPARAMETER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FCLASS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FENUM/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FENUM_005FMEMBER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FINTERFACE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FINTERFACE_005FFOR_005FJS_005FGLOBAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMODULE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMODULE_005FEXPORTED/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMODULE_005FLOCAL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FMEMBER_005FACCESSOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FSTATIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FTYPE_005FMETHOD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FMEMBER_005FACCESSOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FSTATIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FTYPE_005FMETHOD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FMEMBER_005FACCESSOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FSTATIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FTYPE_005FMETHOD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FTYPE_005FPARAMETER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Interfaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=LocalConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Locals/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=MethodPropertyEvent/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Other/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Parameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FHTML_005FCONTROL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FTAG_005FNAME/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FTAG_005FPREFIX/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	
+	
+	
+	
+	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
+	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String></wpf:ResourceDictionary>

--- a/src/SerializerCompatibilityTests/Tester.cs
+++ b/src/SerializerCompatibilityTests/Tester.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Linq;
+using Common;
+using Common.Tests;
+
+class Tester : MarshalByRefObject, ISerializationTester
+{
+    public void Serialize(Type testCaseType, SerializationFormat format, string filePath)
+    {
+        try
+        {
+            var testCase = (TestCase)Activator.CreateInstance(testCaseType);
+
+            var serializer = CreateSerializer(format, testCase.MessageType);
+
+            var testMessage = CreateTestMessage(serializer, testCase);
+
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.Serialize(memoryStream, testMessage);
+
+                memoryStream.Position = 0;
+
+                using (var writer = new FileStream(filePath, FileMode.Create))
+                {
+                    memoryStream.CopyTo(writer);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            throw new Exception(e.Message);
+        }
+    }
+
+    public void Verify(Type testCaseType, SerializationFormat format, string filePath)
+    {
+        try
+        {
+            var testCase = (TestCase)Activator.CreateInstance(testCaseType);
+
+            var serializer = CreateSerializer(format, testCase.MessageType);
+
+            var testMessage = CreateTestMessage(serializer, testCase);
+
+            using (var fileStream = new FileInfo(filePath).OpenRead())
+            {
+                var deserializedMessage = serializer.Deserialize(fileStream).First();
+
+                testCase.CheckIfAreEqual(testMessage, deserializedMessage);
+            }
+        }
+        catch (Exception e)
+        {
+            throw new Exception(e.Message);
+        }
+    }
+
+    ISerializerFacade CreateSerializer(SerializationFormat format, Type messageType)
+    {
+        return format == SerializationFormat.Xml ? (ISerializerFacade)new XmlSerializerFacade(messageType) : new JsonSerializerFacade(messageType);
+    }
+
+    static object CreateTestMessage(ISerializerFacade serializer, TestCase testCase)
+    {
+        var instance = serializer.CreateInstance(testCase.MessageType);
+
+        testCase.Populate(instance);
+
+        return instance;
+    }
+}

--- a/src/SerializerCompatibilityTests/Tests/CompatibilityTests/SerializationCompatibilityTests.cs
+++ b/src/SerializerCompatibilityTests/Tests/CompatibilityTests/SerializationCompatibilityTests.cs
@@ -1,0 +1,56 @@
+﻿namespace Tests.CompatibilityTests
+{
+    using System.IO;
+    using Common.Runner;
+    using Common.Tests;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("All")]
+    public class SerializationCompatibilityTests
+    {
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            outputDirectory = new OutputDirectoryCreator().SetupOutputDirectory("SerializationCompatibilityFiles");
+        }
+
+        string CreateOutputFilePath(TestInfo testCaseInfo)
+        {
+            var nsbVersion = testCaseInfo.RunPackage.Version;
+            var outputFileName = new TestCaseFileName(nsbVersion, testCaseInfo.TestCase.Name, testCaseInfo.Format);
+            var outputFilePath = Path.Combine(outputDirectory, outputFileName.ToString());
+
+            return outputFilePath;
+        }
+
+        string CreateInputFilePath(TestInfo testCaseInfo)
+        {
+            var nsbVersion = testCaseInfo.CheckVersion;
+            var inputFileName = new TestCaseFileName(nsbVersion, testCaseInfo.TestCase.Name, testCaseInfo.Format);
+            var inputFilePath = Path.Combine(outputDirectory, inputFileName.ToString());
+
+            return inputFilePath;
+        }
+
+        [Test, TestCaseSource(typeof(TestInfoGenerator), "Generate", Category = "SerializerCompatibility")]
+        public void Test(TestInfo testInfo)
+        {
+            if (testInfo.Type == TestInfo.TestType.Serialization)
+            {
+                var outputFilePath = CreateOutputFilePath(testInfo);
+
+                testInfo.Runner.Run(tester => tester.Serialize(testInfo.TestCase, testInfo.Format, outputFilePath));
+            }
+
+            if (testInfo.Type == TestInfo.TestType.Deserialization)
+            {
+                var inputFilePath = CreateInputFilePath(testInfo);
+
+                testInfo.Runner.Run(tester => tester.Verify(testInfo.TestCase, testInfo.Format, inputFilePath));
+            }
+        }
+
+        string outputDirectory;
+    }
+}

--- a/src/SerializerCompatibilityTests/Tests/CompatibilityTests/TestInfo.cs
+++ b/src/SerializerCompatibilityTests/Tests/CompatibilityTests/TestInfo.cs
@@ -1,0 +1,32 @@
+﻿namespace Tests.CompatibilityTests
+{
+    using System;
+    using Common.Runner.AppDomains;
+    using Common.Runner.Nuget;
+    using Common.Tests;
+
+    public class TestInfo
+    {
+        public enum TestType
+        {
+            Serialization,
+            Deserialization
+        }
+
+        public Package RunPackage { get; set; }
+        public string CheckVersion { get; set; }
+        public Type TestCase { get; set; }
+        public TestType Type { get; set; }
+        public SerializationFormat Format { get; set; }
+        public AppDomainRunner Runner { get; set; }
+
+        public override string ToString()
+        {
+            if (Type == TestType.Serialization)
+            {
+                return string.Format("Serialization_{0}_{1}_{2}", TestCase.Name, Format, RunPackage.Version);
+            }
+            return string.Format("Deserialization_{0}_{1}_{2}->{3}", TestCase.Name, Format, CheckVersion, RunPackage.Version);
+        }
+    }
+}

--- a/src/SerializerCompatibilityTests/Tests/CompatibilityTests/TestInfoGenerator.cs
+++ b/src/SerializerCompatibilityTests/Tests/CompatibilityTests/TestInfoGenerator.cs
@@ -1,0 +1,154 @@
+﻿namespace Tests.CompatibilityTests
+{
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Common.Runner.AppDomains;
+    using Common.Runner.Nuget;
+    using Common.Tests;
+
+    public class TestInfoGenerator
+    {
+        public IEnumerable<TestInfo> Generate()
+        {
+            TestsGlobal.ClenupAfterPreviousRuns();
+
+            var packages = DownloadPackages(PackageInfos);
+
+            var runners = CreateAppDomainRunners(packages);
+
+            var allTestCases = new TestCaseFinder().FindAll();
+
+            var serializationCases = GenerateSerializationCases(allTestCases, packages, runners);
+            var deserializationCases = GenerateDeserializationCases(allTestCases, packages, runners);
+
+            return serializationCases.Concat(deserializationCases);
+        }
+
+        Package[] DownloadPackages(PackageInfo[] packageInfos)
+        {
+            var resolver = new NuGetPackageResolver(PackageStore, NugetFeed);
+            var packages = new ConcurrentBag<Package>();
+
+            foreach (var packageInfo in packageInfos)
+            {
+                var package = resolver.DownloadPackageWithDependencies(packageInfo).GetAwaiter().GetResult();
+
+                packages.Add(package);
+            }
+
+            var uniquePackages = RemoveVersionDuplicates(packages.ToList());
+
+            return uniquePackages;
+        }
+
+        Package[] RemoveVersionDuplicates(List<Package> availableNServiceBusVersions)
+        {
+            //HINT: We want to remove packageinfos which resolved to the same version number. E.g.
+            //      (5.2,5.3) and (5.0,6.0) could both resolve to 5.2.8 if that's the newest version.
+            return availableNServiceBusVersions.Distinct(new PackageVersionComparer()).ToArray();
+        }
+
+        Dictionary<string, AppDomainRunner> CreateAppDomainRunners(Package[] packages)
+        {
+            var appDomainCreator = new AppDomainCreator();
+            var appDomainRunners = new ConcurrentBag<AppDomainRunner>();
+            var tasks = new List<Task>();
+
+            foreach (var package in packages)
+            {
+                var packageToUse = package;
+
+                var task = Task.Factory.StartNew(() =>
+                {
+                    var domain = appDomainCreator.CreateDomain(TestsGlobal.BinDirectoryTemplate, packageToUse);
+                    var runner = new AppDomainRunner(domain);
+
+                    appDomainRunners.Add(runner);
+                });
+
+                tasks.Add(task);
+            }
+
+            Task.WaitAll(tasks.ToArray());
+
+            return appDomainRunners.ToDictionary(i => i.PackageVersion, i => i);
+        }
+
+        static IEnumerable<TestInfo> GenerateDeserializationCases(List<TestCase> testCases, Package[] packages, Dictionary<string, AppDomainRunner> runners)
+        {
+            var testInfos = from t in testCases
+                from rp in packages
+                from cp in packages
+                from sf in new[]
+                {
+                    SerializationFormat.Xml,
+                    SerializationFormat.Json
+                }
+                where t.SupportsVersion(rp.Version) && t.SupportsVersion(cp.Version) && t.SupportsFormat(sf)
+                select new TestInfo
+                {
+                    RunPackage = rp,
+                    CheckVersion = cp.Version,
+                    TestCase = t.GetType(),
+                    Format = sf,
+                    Type = TestInfo.TestType.Deserialization,
+                    Runner = runners[rp.Version]
+                };
+
+            return testInfos;
+        }
+
+        static IEnumerable<TestInfo> GenerateSerializationCases(List<TestCase> testCases, Package[] packages, Dictionary<string, AppDomainRunner> runners)
+        {
+            var testInfos = from t in testCases
+                from p in packages
+                from sf in new[]
+                {
+                    SerializationFormat.Xml,
+                    SerializationFormat.Json
+                }
+                where t.SupportsVersion(p.Version) && t.SupportsFormat(sf)
+                select new TestInfo
+                {
+                    RunPackage = p,
+                    TestCase = t.GetType(),
+                    Format = sf,
+                    Type = TestInfo.TestType.Serialization,
+                    Runner = runners[p.Version]
+                };
+
+            return testInfos;
+        }
+
+        static string PackageStore = "../..";
+
+        static string NugetFeed = "https://www.myget.org/F/particular";
+
+        static PackageInfo[] PackageInfos =
+        {
+            // latest v3 (3.3)
+            "NServiceBus:(3.0,4.0)",
+
+            // v4 (4.0 - 4.7)
+            "NServiceBus:(4.0,4.1)",
+            "NServiceBus:(4.1,4.2)",
+            "NServiceBus:(4.2,4.3)",
+            "NServiceBus:(4.3,4.4)",
+            "NServiceBus:(4.4,4.5)",
+            "NServiceBus:(4.5,4.6)",
+            "NServiceBus:(4.6,4.7)",
+            "NServiceBus:(4.0,5.0)",
+
+            // v5 (5.0 - 5.2)
+            "NServiceBus:(5.0,5.1)",
+            "NServiceBus:(5.1,5.2)",
+            "NServiceBus:(5.2,5.3)",
+            "NServiceBus:(5.0,6.0)",
+
+            // v6
+            "NServiceBus:(6.0-prerelease,6.1-prerelease)"
+        };
+    }
+}

--- a/src/SerializerCompatibilityTests/Tests/Integration/AppDomainCreatorTests.cs
+++ b/src/SerializerCompatibilityTests/Tests/Integration/AppDomainCreatorTests.cs
@@ -1,0 +1,69 @@
+﻿namespace Tests.Integration
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using Common.Runner.AppDomains;
+    using Common.Runner.Nuget;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AppDomainCreatorTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            nuGetPackageResolver = new NuGetPackageResolver("../..");
+            domainCreator = new AppDomainCreator();
+        }
+
+        AppDomain CreateDomain(PackageInfo packageInfo)
+        {
+            var package = nuGetPackageResolver.DownloadPackageWithDependencies(packageInfo).Result;
+
+            var appDomainDesciptor = domainCreator.CreateDomain(TestsGlobal.BinDirectoryTemplate, package);
+
+            return appDomainDesciptor.AppDomain;
+        }
+
+        [Test]
+        public void Can_setup_an_appdomain()
+        {
+            Assert.That(() => CreateDomain("NServiceBus:5.2.5"), Throws.Nothing);
+        }
+
+        [Test]
+        public void Should_run_in_a_different_appdomain()
+        {
+            var domain = CreateDomain("NServiceBus:5.2.5");
+
+            Assert.That(domain, Is.Not.EqualTo(AppDomain.CurrentDomain));
+        }
+
+        [Test]
+        public void Each_appdomain_should_have_a_different_version_of_nservicebus()
+        {
+            var firstDomain = CreateDomain("NServiceBus:[5.2.5]");
+            var secondDomain = CreateDomain("NServiceBus:[5.0.5]");
+
+            var nsb525 = Directory.GetFiles(firstDomain.BaseDirectory, "NServiceBus.Core.dll").First();
+            var nsb505 = Directory.GetFiles(secondDomain.BaseDirectory, "NServiceBus.Core.dll").First();
+
+            Assert.That(FileVersionInfo.GetVersionInfo(nsb525).FileVersion, Is.EqualTo("5.2.5.0"));
+            Assert.That(FileVersionInfo.GetVersionInfo(nsb505).FileVersion, Is.EqualTo("5.0.5.0"));
+        }
+
+        [TestCase("NServiceBus:[5.2.5]", "NServiceBus 5.2.5")]
+        [TestCase("NServiceBus:[5.0.5]", "NServiceBus 5.0.5")]
+        public void Run_task_inside_correct_appdomain(string package, string domainName)
+        {
+            var domain = CreateDomain(package);
+
+            Assert.That(domain.GetData("FriendlyName"), Is.EqualTo(domainName));
+        }
+
+        AppDomainCreator domainCreator;
+        NuGetPackageResolver nuGetPackageResolver;
+    }
+}

--- a/src/SerializerCompatibilityTests/Tests/Integration/NuGetPackageResolverTests.cs
+++ b/src/SerializerCompatibilityTests/Tests/Integration/NuGetPackageResolverTests.cs
@@ -1,0 +1,51 @@
+﻿namespace Tests.Integration
+{
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Common.Runner.Nuget;
+    using NUnit.Framework;
+    using Paket;
+
+    [TestFixture]
+    public class NuGetPackageResolverTests
+    {
+        [TestFixtureSetUp]
+        public void FixtureSetUp()
+        {
+            testPackagesDirectory = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "../.."));
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            resolver = new NuGetPackageResolver(testPackagesDirectory);
+        }
+
+        [Test]
+        public async Task Resolves_package_by_version()
+        {
+            var package = await resolver.DownloadPackageWithDependencies(new PackageInfo("NServiceBus", "[5.2.5]"));
+            Assert.That(package.Files.Any(info => info.Name == "NServiceBus.Core.dll"));
+        }
+
+        [Test]
+        public async Task Resolves_additional_assemblies()
+        {
+            var package = await resolver.DownloadPackageWithDependencies(new PackageInfo("NServiceBus", "(4.0,4.1)"));
+            Assert.That(package.Files.Any(info => info.Name == "NServiceBus.dll"));
+        }
+
+        [Test]
+        public async Task Gets_latest_package_version_for_major_minor()
+        {
+            var package = await resolver.DownloadPackageWithDependencies("NServiceBus:(5.2,5.3)");
+            var actual = SemVer.Parse(package.Version);
+            var expected = SemVer.Parse("5.2.5");
+            Assert.That(actual, Is.GreaterThanOrEqualTo(expected));
+        }
+
+        string testPackagesDirectory;
+        NuGetPackageResolver resolver;
+    }
+}

--- a/src/SerializerCompatibilityTests/Tests/Integration/SerializationTests.cs
+++ b/src/SerializerCompatibilityTests/Tests/Integration/SerializationTests.cs
@@ -1,0 +1,59 @@
+﻿namespace Tests.Integration
+{
+    using System;
+    using System.IO;
+    using Common.Runner;
+    using Common.Runner.AppDomains;
+    using Common.Runner.Nuget;
+    using Common.Tests;
+    using Common.Tests.TestCases;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SerializationTests
+    {
+        AppDomainRunner CreateTaskRunner(PackageInfo packages)
+        {
+            var package = nuGetPackageResolver.DownloadPackageWithDependencies(packages).Result;
+            var domain = domainCreator.CreateDomain(TestsGlobal.BinDirectoryTemplate, package);
+
+            var runner = new AppDomainRunner(domain);
+
+            return runner;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var outputDirectory = new OutputDirectoryCreator().SetupOutputDirectory("TestCaseOutput");
+
+            filePath = Path.Combine(outputDirectory, "testcase.dat");
+            nuGetPackageResolver = new NuGetPackageResolver("../..");
+            domainCreator = new AppDomainCreator();
+        }
+
+        [Test]
+        public void Failing_test_case_throws_an_exception()
+        {
+            var runner = CreateTaskRunner("NServiceBus:5.2.5");
+
+            runner.Run(t => t.Serialize(typeof(Failing), SerializationFormat.Xml, filePath));
+
+            Assert.That(() => runner.Run(t => t.Verify(typeof(Failing), SerializationFormat.Xml, filePath)), Throws.TypeOf<Exception>());
+        }
+
+        [Test]
+        public void Working_test_case_does_not_throw()
+        {
+            var runner = CreateTaskRunner("NServiceBus:5.2.5");
+
+            runner.Run(t => t.Serialize(typeof(Passing), SerializationFormat.Json, filePath));
+
+            Assert.That(() => runner.Run(t => t.Verify(typeof(Passing), SerializationFormat.Json, filePath)), Throws.Nothing);
+        }
+
+        NuGetPackageResolver nuGetPackageResolver;
+        AppDomainCreator domainCreator;
+        string filePath;
+    }
+}

--- a/src/SerializerCompatibilityTests/Tests/Tests.csproj
+++ b/src/SerializerCompatibilityTests/Tests/Tests.csproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FEAAE402-8ED0-47FB-8E54-42B1D7F654CC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Tests</RootNamespace>
+    <AssemblyName>Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Paket.Core, Version=2.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Paket.Core.2.5.0\lib\net45\Paket.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CompatibilityTests\SerializationCompatibilityTests.cs" />
+    <Compile Include="CompatibilityTests\TestInfo.cs" />
+    <Compile Include="CompatibilityTests\TestInfoGenerator.cs" />
+    <Compile Include="Integration\AppDomainCreatorTests.cs" />
+    <Compile Include="Integration\NuGetPackageResolverTests.cs" />
+    <Compile Include="Integration\SerializationTests.cs" />
+    <Compile Include="TestsGlobal.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj">
+      <Project>{572499ED-E234-4C66-BD6E-D5A845065C5F}</Project>
+      <Name>Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/SerializerCompatibilityTests/Tests/TestsGlobal.cs
+++ b/src/SerializerCompatibilityTests/Tests/TestsGlobal.cs
@@ -1,0 +1,38 @@
+﻿namespace Tests
+{
+    using System.IO;
+    using System.Linq;
+    using NUnit.Framework;
+
+    [SetUpFixture]
+    public class TestsGlobal
+    {
+        [SetUp]
+        public void RunsBeforeAnyTest()
+        {
+            ClenupAfterPreviousRuns();
+        }
+
+        public static void ClenupAfterPreviousRuns()
+        {
+            if (CleanupDone == false)
+            {
+                RemoveAppDomainCodeBaseDirs();
+            }
+
+            CleanupDone = true;
+        }
+
+        static void RemoveAppDomainCodeBaseDirs()
+        {
+            new DirectoryInfo(".")
+                .GetDirectories(BinDriectorySearchPattern).ToList()
+                .ForEach(d => d.Delete(true));
+        }
+
+        public static string BinDirectoryTemplate = "NServiceBus_{0}_{1}";
+
+        static string BinDriectorySearchPattern = string.Format(BinDirectoryTemplate, "*", "*");
+        static bool CleanupDone;
+    }
+}

--- a/src/SerializerCompatibilityTests/Tests/packages.config
+++ b/src/SerializerCompatibilityTests/Tests/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="Paket.Core" version="2.5.0" allowedVersions="[2.5.0]" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
This fixes https://github.com/Particular/ProductionTests/issues/50.
Tests have been updated to run with the latest NSB6.

We're streamlining the process of End-to-End testing, and moving existing tests from a private ProductionTests repo to here.
This PR moves the SerializationCompatTests.