### PR TITLE
change default splunk log level to Info

### DIFF
--- a/src/PerformanceTests/Utils/Statistics.cs
+++ b/src/PerformanceTests/Utils/Statistics.cs
@@ -118,7 +118,7 @@ public class Statistics : IDisposable
 
     static void LogStats(string key, double value, string unit)
     {
-        logger.Debug($"{key}: {value:0.0} ({unit})");
+        logger.Info($"{key}: {value:0.0} ({unit})");
     }
 
     void ConfigureSplunk()


### PR DESCRIPTION
Change splunk logging to info so the output is visible by default when running locally.

Connects to #3