### PR TITLE
Added SendThroughputFixture with send throughput tests using for, par…

### DIFF
--- a/src/PerformanceTests/Common/Common.Data.projitems
+++ b/src/PerformanceTests/Common/Common.Data.projitems
@@ -36,6 +36,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)Scenarios\SendLocalOneOnOne\SendLocalOneOnOneRunner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Scenarios\SendLocalOneOnOne\SendLocalOneOnOneRunner.V5.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Scenarios\SendLocalOneOnOne\SendLocalOneOnOneRunner.V6.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Scenarios\SendLoop\BaseLoop.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Scenarios\SendLoop\ForRunner.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Scenarios\SendLoop\ParallelForRunner.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Scenarios\SendLoop\SendLoop.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Scenarios\SendLoop\TaskArrayRunner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SerializerProfile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StatisticsUoW.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Statistics\SimpleStatisticsFeature.V5.cs" />

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/ForRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/ForRunner.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+class ForRunner : SendLoop
+{
+    protected override async Task Batch(int count, Func<Task> action)
+    {
+        for (var i = 0; i < count; i++) await action();
+    }
+}

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/ParallelForRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/ParallelForRunner.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading.Tasks;
+
+class ParallelForRunner : SendLoop
+{
+    ParallelOptions options = new ParallelOptions();
+
+    protected override Task Batch(int count, Func<Task> action)
+    {
+        Parallel.For(0, count, options, i =>
+        {
+            action().GetAwaiter().GetResult();
+        });
+        return Task.FromResult(0);
+    }
+}

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/SendLoop.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/SendLoop.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using NServiceBus;
+
+abstract class SendLoop : BaseLoop
+{
+
+    protected SendLoop()
+    {
+        SendOnly = true;
+    }
+    protected override Task SendMessage()
+    {
+        return Session.SendLocal(new Command { Data = Data });
+    }
+
+    class Command : ICommand
+    {
+        public byte[] Data { get; set; }
+    }
+}

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/TaskArrayRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/TaskArrayRunner.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+class TaskArrayRunner : SendLoop
+{
+    protected override Task Batch(int count, Func<Task> action)
+    {
+        var sends = new Task[count];
+        for (var i = 0; i < count; i++) sends[i] = action();
+        return Task.WhenAll(sends);
+    }
+}

--- a/src/PerformanceTests/Tests/Categories/Base.cs
+++ b/src/PerformanceTests/Tests/Categories/Base.cs
@@ -42,6 +42,21 @@ namespace Categories
             Tasks(permutation);
         }
 
+        public virtual void ForRunner(Permutation permutation)
+        {
+            Tasks(permutation);
+        }
+
+        public virtual void ParallelForRunner(Permutation permutation)
+        {
+            Tasks(permutation);
+        }
+
+        public virtual void TaskArrayRunner(Permutation permutation)
+        {
+            Tasks(permutation);
+        }
+
         void Tasks(Permutation permutation, [CallerMemberName] string memberName = "")
         {
             var fixtureType = GetType();

--- a/src/PerformanceTests/Tests/Categories/SendThroughputFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/SendThroughputFixture.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Tests.Permutations;
+using Variables;
+
+namespace Categories
+{ 
+    [TestFixture(Description = "Send throughput", Category = "Performance")]
+    public class SendThroughputFixture : Base
+    {
+        [TestCaseSource(nameof(CreatePermutations))]
+        public override void ForRunner(Permutation permutation)
+        {
+            base.ForRunner(permutation);
+        }
+
+        [TestCaseSource(nameof(CreatePermutations))]
+        public override void ParallelForRunner(Permutation permutation)
+        {
+            base.ParallelForRunner(permutation);
+        }
+
+        [TestCaseSource(nameof(CreatePermutations))]
+        public override void TaskArrayRunner(Permutation permutation)
+        {
+            base.TaskArrayRunner(permutation);
+        }
+
+        static IEnumerable<Permutation> CreatePermutations()
+        {
+            return PermutationGenerator.Generate(new Permutations
+            {
+                Versions = new[] { NServiceBusVersion.V6 },
+                OutboxModes = new [] { Outbox.Off },
+                MessageSizes = (MessageSize[])Enum.GetValues(typeof(MessageSize)),
+            });
+        }
+    }
+}

--- a/src/PerformanceTests/Tests/Tests.csproj
+++ b/src/PerformanceTests/Tests/Tests.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Categories\SendThroughputFixture.cs" />
     <Compile Include="Categories\DistributorFixture.cs" />
     <Compile Include="Categories\PlatformFixture.cs" />
     <Compile Include="Categories\MsmqFixture.cs" />


### PR DESCRIPTION
Different ways of sending a large number of messages:

- Regular for loop
- Parallel.For
- Wait.All Task array

Introduced a new loop class that just continuously loops without using a `CountdownEvent` as a gate. It also captures some statistics.

The existing loop also logs some statistics now:

- LoopLastBatchSize(last)
- LoopCount
- LoopDuration
- LoopThroughputAvg
- LoopLatency