### PR TITLE
Logging adjustments

### DIFF
--- a/src/PerformanceTests/NServiceBus5/App.Release.config
+++ b/src/PerformanceTests/NServiceBus5/App.Release.config
@@ -2,12 +2,12 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
-      <target xdt:Transform="RemoveAll" />
       <target name="splunk" xsi:type="Network" address="tcp://deploy.particular.net:8001" layout="${level}~${gdc:item=sessionid}~${gdc:item=testcategory}~${gdc:item=testdescription}~${gdc:item=permutationId}~${message}~${gdc:item=testname}~${newline}" xdt:Transform="Insert" />
     </targets>
     <rules>
-      <logger name="*" xdt:Transform="RemoveAll" />
-      <logger name="Statistics" minlevel="Debug" writeTo="splunk" xdt:Transform="Insert" />
+      <logger xdt:Transform="RemoveAll" />
+      <logger xdt:Transform="Insert" name="Statistics" minlevel="Debug" writeTo="splunk" />
+      <logger xdt:Transform="Insert" name="*" minlevel="Warn" writeTo="file" />
     </rules>
   </nlog>
   <appSettings>

--- a/src/PerformanceTests/NServiceBus5/App.config
+++ b/src/PerformanceTests/NServiceBus5/App.config
@@ -10,8 +10,8 @@
 
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
-      <target name="file" xsi:type="File" fileName="trace.log" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
-      <target name="trace" xsi:type="OutputDebugString" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}"/>
+      <target name="file" xsi:type="File" fileName="trace.log" layout="${longdate:universalTime=true}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
+      <target name="trace" xsi:type="OutputDebugString" layout="${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}"/>
       <target name="console" xsi:type="ColoredConsole" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
     </targets>
     <rules>

--- a/src/PerformanceTests/NServiceBus6/App.Release.config
+++ b/src/PerformanceTests/NServiceBus6/App.Release.config
@@ -2,12 +2,12 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
-      <target xdt:Transform="RemoveAll" />
       <target name="splunk" xsi:type="Network" address="tcp://deploy.particular.net:8001" layout="${level}~${gdc:item=sessionid}~${gdc:item=testcategory}~${gdc:item=testdescription}~${gdc:item=permutationId}~${message}~${gdc:item=testname}~${newline}" xdt:Transform="Insert" />
     </targets>
     <rules>
-      <logger name="*" xdt:Transform="RemoveAll" />
-      <logger name="Statistics" minlevel="Debug" writeTo="splunk" xdt:Transform="Insert" />
+      <logger xdt:Transform="RemoveAll" />
+      <logger xdt:Transform="Insert" name="Statistics" minlevel="Debug" writeTo="splunk" />
+      <logger xdt:Transform="Insert" name="*" minlevel="Warn" writeTo="file" />
     </rules>
   </nlog>
   <appSettings>

--- a/src/PerformanceTests/NServiceBus6/App.config
+++ b/src/PerformanceTests/NServiceBus6/App.config
@@ -10,8 +10,8 @@
 
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
-      <target name="file" xsi:type="File" fileName="trace.log" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
-      <target name="trace" xsi:type="OutputDebugString" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}"/>
+      <target name="file" xsi:type="File" fileName="trace.log" layout="${longdate:universalTime=true}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
+      <target name="trace" xsi:type="OutputDebugString" layout="${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}"/>
       <target name="console" xsi:type="ColoredConsole" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
     </targets>
     <rules>


### PR DESCRIPTION
- Logging WARN and higher to file log in release build
- Timestamps in file log formatted in UTC
- Timestamps removed in Trace output as that records its own timestamps.