### PR TITLE
Unicastbus config check

### DIFF
--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -24,14 +24,13 @@ public abstract class BaseRunner : IConfigurationSource, IContext
 
     public Permutation Permutation { get; private set; }
     public string EndpointName { get; private set; }
-    protected ISession Session { get; private set; }
+    ISession Session { get; set; }
 
     protected byte[] Data { private set; get; }
     protected bool SendOnly { get; set; }
 
     public virtual void Execute(Permutation permutation, string endpointName)
     {
-
         Permutation = permutation;
         EndpointName = endpointName;
 
@@ -42,7 +41,7 @@ public abstract class BaseRunner : IConfigurationSource, IContext
 
         try
         {
-            Start();
+            Start(Session);
             Log.InfoFormat("Warmup: {0}", Settings.WarmupDuration);
             Thread.Sleep(Settings.WarmupDuration);
             Statistics.Instance.Reset(GetType().Name);
@@ -57,7 +56,7 @@ public abstract class BaseRunner : IConfigurationSource, IContext
         }
     }
 
-    protected virtual void Start()
+    protected virtual void Start(ISession session)
     {
     }
 

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -227,12 +227,12 @@ public abstract class BaseRunner : IConfigurationSource, IContext
     {
         IConfigureUnicastBus configureUnicastBus;
 
+        //read from existing config 
+        var config = (UnicastBusConfig)ConfigurationManager.GetSection(typeof(UnicastBusConfig).Name);
+        if (config != null) throw new InvalidOperationException("UnicastBUs Configuration should be in code using IConfigureUnicastBus interface.");
+
         if (typeof(T) == typeof(UnicastBusConfig) && null != (configureUnicastBus = this as IConfigureUnicastBus))
         {
-            //read from existing config 
-            var config = (UnicastBusConfig)ConfigurationManager.GetSection(typeof(UnicastBusConfig).Name);
-            if (config != null) throw new InvalidOperationException("UnicastBUs Configuration should be in code using IConfigureUnicastBus interface.");
-
             return new UnicastBusConfig
             {
                 MessageEndpointMappings = configureUnicastBus.GenerateMappings()

--- a/src/PerformanceTests/Common/Scenarios/GatedPublish/GatedPublishRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/GatedPublish/GatedPublishRunner.cs
@@ -10,9 +10,9 @@ using NServiceBus.Config;
 /// </summary>
 class GatedPublishRunner : LoopRunner, IConfigureUnicastBus
 {
-    protected override Task SendMessage()
+    protected override Task SendMessage(ISession session)
     {
-        return Session.Publish(new Event
+        return session.Publish(new Event
         {
             Data = Data
         });

--- a/src/PerformanceTests/Common/Scenarios/GatedSendLocal/GatedSendLocalRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/GatedSendLocal/GatedSendLocalRunner.cs
@@ -9,9 +9,9 @@ using NServiceBus;
 /// </summary>
 class GatedSendLocalRunner : LoopRunner
 {
-    protected override Task SendMessage()
+    protected override Task SendMessage(ISession session)
     {
-        return Session.SendLocal(new Command
+        return session.SendLocal(new Command
         {
             Data = Data
         });

--- a/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
@@ -18,12 +18,12 @@ abstract class LoopRunner : BaseRunner
     CancellationTokenSource stopLoop { get; set; }
     bool Shutdown { get; set; }
     int BatchSize { get; set; } = 16;
-    protected abstract Task SendMessage();
+    protected abstract Task SendMessage(ISession session);
 
-    protected override void Start()
+    protected override void Start(ISession session)
     {
         stopLoop = new CancellationTokenSource();
-        loopTask = Task.Factory.StartNew(Loop, TaskCreationOptions.LongRunning);
+        loopTask = Task.Factory.StartNew(() => Loop(session), TaskCreationOptions.LongRunning);
     }
 
     protected override void Stop()
@@ -39,7 +39,7 @@ abstract class LoopRunner : BaseRunner
         }
     }
 
-    async Task Loop(object o)
+    async Task Loop(ISession session)
     {
         try
         {
@@ -57,7 +57,7 @@ abstract class LoopRunner : BaseRunner
                     countdownEvent.Reset(BatchSize);
                     var batchDuration = Stopwatch.StartNew();
 
-                    await TaskHelper.ParallelFor(BatchSize, SendMessage);
+                    await TaskHelper.ParallelFor(BatchSize, () => SendMessage(session));
 
                     count += BatchSize;
 

--- a/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.cs
@@ -13,9 +13,9 @@ partial class SendLocalOneOnOneRunner : BaseRunner
 {
     const int seedSize = 1000;
 
-    protected override void Start()
+    protected override void Start(ISession session)
     {
-        TaskHelper.ParallelFor(seedSize, () => Session.SendLocal(new Command { Data = Data })).GetAwaiter().GetResult();
+        TaskHelper.ParallelFor(seedSize, () => session.SendLocal(new Command { Data = Data })).GetAwaiter().GetResult();
     }
 
     protected override void Stop()

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/BaseLoop.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/BaseLoop.cs
@@ -18,13 +18,14 @@ abstract class BaseLoop : BaseRunner
     CancellationTokenSource stopLoop { get; set; }
     bool Shutdown { get; set; }
     int BatchSize { get; set; } = 16;
-    protected abstract Task SendMessage();
+    protected abstract Task SendMessage(ISession session);
 
-    protected override void Start()
+    protected override void Start(ISession session)
     {
         stopLoop = new CancellationTokenSource();
-        loopTask = Task.Factory.StartNew(Loop, TaskCreationOptions.LongRunning);
+        loopTask = Task.Factory.StartNew(() => Loop(session), TaskCreationOptions.LongRunning);
     }
+
 
     protected override void Stop()
     {
@@ -39,7 +40,7 @@ abstract class BaseLoop : BaseRunner
         }
     }
 
-    async Task Loop(object o)
+    async Task Loop(ISession session)
     {
         try
         {
@@ -57,7 +58,7 @@ abstract class BaseLoop : BaseRunner
 
                     var batchDuration = Stopwatch.StartNew();
 
-                    await Batch(BatchSize, SendMessage);
+                    await Batch(BatchSize, () => SendMessage(session));
 
                     count += BatchSize;
 

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/SendLoop.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/SendLoop.cs
@@ -8,9 +8,9 @@ abstract class SendLoop : BaseLoop
     {
         SendOnly = true;
     }
-    protected override Task SendMessage()
+    protected override Task SendMessage(ISession session)
     {
-        return Session.SendLocal(new Command { Data = Data });
+        return session.SendLocal(new Command { Data = Data });
     }
 
     class Command : ICommand


### PR DESCRIPTION
Minor change that moves a check to see if unicastbus was configured in app.config to be executed earlier. When developers try to config it there, they will be pointed towards a specific interface to be implemented. In the previous version, they already had to implement that interface to be able to see the warning, which is a bit weird.

Note: merge this AFTER session-intent was merged. Sorry for confusion! :)