### PR TITLE
[WIP] Add FLR to Azure Storage Queues to bypass throttling 500 errors

### DIFF
--- a/src/PerformanceTests/Transport.V5.AzureStorageQueues.V6/AzureStorageQueueProfile.cs
+++ b/src/PerformanceTests/Transport.V5.AzureStorageQueues.V6/AzureStorageQueueProfile.cs
@@ -37,6 +37,19 @@ class FlrConfig : IConfigurationSource
             return flrConfig as T;
         }
 
+        // To provide SLR Config
+        if (typeof(T) == typeof(SecondLevelRetriesConfig))
+        {
+            SecondLevelRetriesConfig slrConfig = new SecondLevelRetriesConfig
+            {
+                Enabled = true,
+                NumberOfRetries = 2,
+                TimeIncrease = TimeSpan.FromSeconds(10)
+            };
+
+            return slrConfig as T;
+        }
+
         // To in app.config for other sections not defined in this method, otherwise return null.
         return ConfigurationManager.GetSection(typeof(T).Name) as T;
     }

--- a/src/PerformanceTests/Transport.V5.AzureStorageQueues.V6/AzureStorageQueueProfile.cs
+++ b/src/PerformanceTests/Transport.V5.AzureStorageQueues.V6/AzureStorageQueueProfile.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using NServiceBus;
 using Variables;
+using NServiceBus.Config;
+using NServiceBus.Config.ConfigurationSource;
+using System.Configuration;
 
 class AzureStorageQueueProfile : IProfile, INeedContext
 {
@@ -11,7 +14,30 @@ class AzureStorageQueueProfile : IProfile, INeedContext
         if ((int)MessageSize.Medium < (int)Context.Permutation.MessageSize) throw new NotSupportedException($"Message size {Context.Permutation.MessageSize} not supported by ASQ.");
 
         busConfiguration
+            .CustomConfigurationSource(new FlrConfig());
+
+        busConfiguration
             .UseTransport<AzureStorageQueueTransport>()
             .ConnectionString(ConfigurationHelper.GetConnectionString("AzureStorageQueue"));
+    }
+}
+
+class FlrConfig : IConfigurationSource
+{
+    public T GetConfiguration<T>() where T : class, new()
+    {
+        //To Provide FLR Config
+        if (typeof(T) == typeof(TransportConfig))
+        {
+            TransportConfig flrConfig = new TransportConfig
+            {
+                MaxRetries = 2
+            };
+
+            return flrConfig as T;
+        }
+
+        // To in app.config for other sections not defined in this method, otherwise return null.
+        return ConfigurationManager.GetSection(typeof(T).Name) as T;
     }
 }

--- a/src/PerformanceTests/Transport.V5.AzureStorageQueues.V6/Transport.V5.AzureStorageQueues_v6.csproj
+++ b/src/PerformanceTests/Transport.V5.AzureStorageQueues.V6/Transport.V5.AzureStorageQueues_v6.csproj
@@ -73,6 +73,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>

--- a/src/PerformanceTests/Transport.V6.AzureStorageQueues.V7/AzureStorageQueuesProfile.cs
+++ b/src/PerformanceTests/Transport.V6.AzureStorageQueues.V7/AzureStorageQueuesProfile.cs
@@ -38,6 +38,19 @@ class FlrConfig : IConfigurationSource
             return flrConfig as T;
         }
 
+        // To provide SLR Config
+        if (typeof(T) == typeof(SecondLevelRetriesConfig))
+        {
+            SecondLevelRetriesConfig slrConfig = new SecondLevelRetriesConfig
+            {
+                Enabled = true,
+                NumberOfRetries = 2,
+                TimeIncrease = TimeSpan.FromSeconds(10)
+            };
+
+            return slrConfig as T;
+        }
+
         // To in app.config for other sections not defined in this method, otherwise return null.
         return ConfigurationManager.GetSection(typeof(T).Name) as T;
     }

--- a/src/PerformanceTests/Transport.V6.AzureStorageQueues.V7/AzureStorageQueuesProfile.cs
+++ b/src/PerformanceTests/Transport.V6.AzureStorageQueues.V7/AzureStorageQueuesProfile.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using NServiceBus;
 using Variables;
+using NServiceBus.Config.ConfigurationSource;
+using NServiceBus.Config;
+using System.Configuration;
 
 class AzureStorageQueuesProfile : IProfile, INeedContext
 {
@@ -11,8 +14,31 @@ class AzureStorageQueuesProfile : IProfile, INeedContext
         if ((int)MessageSize.Medium < (int)Context.Permutation.MessageSize) throw new NotSupportedException($"Message size {Context.Permutation.MessageSize} not supported by ASQ.");
 
         endpointConfiguration
+            .CustomConfigurationSource(new FlrConfig());
+
+        endpointConfiguration
             .UseTransport<AzureStorageQueueTransport>()
             .ConnectionString(ConfigurationHelper.GetConnectionString("AzureStorageQueue"));
     }
 
+}
+
+class FlrConfig : IConfigurationSource
+{
+    public T GetConfiguration<T>() where T : class, new()
+    {
+        //To Provide FLR Config
+        if (typeof(T) == typeof(TransportConfig))
+        {
+            TransportConfig flrConfig = new TransportConfig
+            {
+                MaxRetries = 2
+            };
+
+            return flrConfig as T;
+        }
+
+        // To in app.config for other sections not defined in this method, otherwise return null.
+        return ConfigurationManager.GetSection(typeof(T).Name) as T;
+    }
 }


### PR DESCRIPTION
We are getting intermittent 500 errors from Azure. This appears to be Azure throttling us.

https://azure.microsoft.com/en-us/documentation/articles/storage-scalability-targets/

By enabling FLR and SLR the retries _should_ allow the messages to process correctly.

This does however allow the chance that the tests will now fail due to running over the test timecap.