### PR TITLE
Added .ConfigureAwait(false) + using MaxDegreeOfParallelism + seed stats

### DIFF
--- a/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.cs
@@ -15,7 +15,8 @@ partial class SendLocalOneOnOneRunner : BaseRunner
 
     protected override void Start(ISession session)
     {
-        TaskHelper.ParallelFor(seedSize, () => session.SendLocal(new Command { Data = Data })).GetAwaiter().GetResult();
+        TaskHelper.ParallelFor(seedSize, () => session.SendLocal(new Command { Data = Data }))
+            .ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
     protected override void Stop()

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/ParallelForRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/ParallelForRunner.cs
@@ -9,7 +9,7 @@ class ParallelForRunner : SendLoop
     {
         Parallel.For(0, count, options, i =>
         {
-            action().GetAwaiter().GetResult();
+            action().ConfigureAwait(false).GetAwaiter().GetResult();
         });
         return Task.FromResult(0);
     }


### PR DESCRIPTION
### Added .ConfigureAwait(false)

Using ConfigureAwait(false) has a positive effect in the seed throughput for NServiceBus V6.

### MaxDegreeOfParallelism while seeding

V6 benefits from limiting the max degree of parallelism. This does have a small negative impact on V5 performance.

### Seeding statistics

The SeedCount and SeedDuration are now added to the test statistics logging.