### PR TITLE
Cleaning database before test runs

### DIFF
--- a/src/NHPersistenceCompatibilityTests/Common/NHibernateConnectionInfo.cs
+++ b/src/NHPersistenceCompatibilityTests/Common/NHibernateConnectionInfo.cs
@@ -4,8 +4,8 @@ namespace Common
 {
     public class NHibernateConnectionInfo
     {
-        const string Dialect = "NHibernate.Dialect.MsSql2012Dialect";
-        const string ConnectionString = @"Data Source=localhost\SQLEXPRESS;Initial Catalog=persistencetests;Integrated Security=True";
+        public const string Dialect = "NHibernate.Dialect.MsSql2012Dialect";
+        public const string ConnectionString = @"Data Source=localhost\SQLEXPRESS;Initial Catalog=persistencetests;Integrated Security=True";
 
         public static IDictionary<string, string> Settings = new Dictionary<string, string>
         {

--- a/src/NHPersistenceCompatibilityTests/PersistenceCompatibilityTests/Database.cs
+++ b/src/NHPersistenceCompatibilityTests/PersistenceCompatibilityTests/Database.cs
@@ -1,0 +1,32 @@
+﻿namespace PersistenceCompatibilityTests
+{
+    using System.Data.SqlClient;
+    using Common;
+
+    public class Database
+    {
+        public static void Cleanup()
+        {
+            var connectionString = NHibernateConnectionInfo.ConnectionString;
+            var builder = new SqlConnectionStringBuilder(connectionString);
+            var initialCatalog = builder.InitialCatalog;
+            builder.InitialCatalog = "master";
+
+            using (var connection = new SqlConnection(builder.ConnectionString))
+            using (var command = connection.CreateCommand())
+            {
+                connection.Open();
+
+                var query = @"IF EXISTS(SELECT * from sys.databases where name = '{0}')
+                              BEGIN 
+                                ALTER DATABASE [{0}] SET  SINGLE_USER WITH ROLLBACK IMMEDIATE
+                                DROP DATABASE [{0}]
+                              END 
+                            CREATE DATABASE [{0}]";
+
+                command.CommandText = string.Format(query, initialCatalog);
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+}

--- a/src/NHPersistenceCompatibilityTests/PersistenceCompatibilityTests/NHibernatePersistenceTests.cs
+++ b/src/NHPersistenceCompatibilityTests/PersistenceCompatibilityTests/NHibernatePersistenceTests.cs
@@ -12,8 +12,9 @@ namespace PersistenceCompatibilityTests
         [OneTimeSetUp]
         public void Setup()
         {
+            Database.Cleanup();
             persisterProvider = new PersisterProvider();
-            persisterProvider.Initialize(NHibernatePackageVersions);    
+            persisterProvider.Initialize(NHibernatePackageVersions);
         }
 
         [OneTimeTearDown]

--- a/src/NHPersistenceCompatibilityTests/PersistenceCompatibilityTests/PersistenceCompatibilityTests.csproj
+++ b/src/NHPersistenceCompatibilityTests/PersistenceCompatibilityTests/PersistenceCompatibilityTests.csproj
@@ -56,6 +56,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Database.cs" />
     <Compile Include="NHibernatePersistenceTests.cs" />
     <Compile Include="PersisterFacade.cs" />
     <Compile Include="PersisterProvider.cs" />


### PR DESCRIPTION
Cleans the database tables when test starts. This would allow us access the tables (for diagnostics) after a test fails.