### PR TITLE
NHibernateProfile setup using wrong permutation value

### DIFF
--- a/src/PerformanceTests/Persistence.V5.NHibernate.V6/NHibernateProfile.cs
+++ b/src/PerformanceTests/Persistence.V5.NHibernate.V6/NHibernateProfile.cs
@@ -16,7 +16,7 @@ class NHibernateProfile : IProfile, ISetup, INeedPermutation
 
     void ISetup.Setup()
     {
-        var cs = ConfigurationHelper.GetConnectionString(Permutation.Transport.ToString());
+        var cs = ConfigurationHelper.GetConnectionString(Permutation.Persister.ToString());
         var sql = Assembly.GetExecutingAssembly().GetManifestResourceText("Persistence.V5.NHibernate.init.sql");
         SqlHelper.CreateDatabase(cs);
         SqlHelper.ExecuteScript(cs, sql);

--- a/src/PerformanceTests/Persistence.V6.NHibernate.V7/NHibernateProfile.cs
+++ b/src/PerformanceTests/Persistence.V6.NHibernate.V7/NHibernateProfile.cs
@@ -16,7 +16,7 @@ class NHibernateProfile : IProfile, ISetup, INeedPermutation
 
     void ISetup.Setup()
     {
-        var cs = ConfigurationHelper.GetConnectionString(Permutation.Transport.ToString());
+        var cs = ConfigurationHelper.GetConnectionString(Permutation.Persister.ToString());
         var sql = Assembly.GetExecutingAssembly().GetManifestResourceText("Persistence.V6.NHibernate.init.sql");
         SqlHelper.CreateDatabase(cs);
         SqlHelper.ExecuteScript(cs, sql);


### PR DESCRIPTION
Setup was using incorrect permutation value (Transport) to retrieve connection string, now set to persister.