### PR TITLE
Performance tests async optimizations

### DIFF
--- a/src/PerformanceTests/Common/Program.cs
+++ b/src/PerformanceTests/Common/Program.cs
@@ -49,7 +49,8 @@ namespace Host
                     var runnableTest = permutation.Tests.Select(x => (BaseRunner)assembly.CreateInstance(x)).Single();
 
                     Log.InfoFormat("Executing scenario: {0}", runnableTest);
-                    runnableTest.Execute(permutation, endpointName);
+                    runnableTest.Execute(permutation, endpointName)
+                        .ConfigureAwait(false).GetAwaiter().GetResult();
                 }
             }
             catch (NotSupportedException nsex)

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -37,12 +37,12 @@ public abstract class BaseRunner : IConfigurationSource, IContext
 
         InitData();
 
-        await CreateSeedData();
-        await CreateEndpoint();
+        await CreateSeedData().ConfigureAwait(false);
+        await CreateEndpoint().ConfigureAwait(false);
 
         try
         {
-            await Start(Session);
+            await Start(Session).ConfigureAwait(false);
 
             if (!IsSeedingData)
             {
@@ -60,11 +60,11 @@ public abstract class BaseRunner : IConfigurationSource, IContext
             await Task.Delay(runDuration).ConfigureAwait(false);
             Statistics.Instance.Dump();
 
-            await Stop();
+            await Stop().ConfigureAwait(false);
         }
         finally
         {
-            await Session.Close();
+            await Session.Close().ConfigureAwait(false);
         }
     }
 
@@ -76,15 +76,15 @@ public abstract class BaseRunner : IConfigurationSource, IContext
     protected virtual Task Stop()
     {
         return Task.FromResult(0);
-;    }
+    }
 
     async Task CreateSeedData()
     {
         var seedCreator = this as ICreateSeedData;
         if (seedCreator == null) return;
 
-        await CreateOrPurgeQueues();
-        await CreateSendOnlyEndpoint();
+        await CreateOrPurgeQueues().ConfigureAwait(false);
+        await CreateSendOnlyEndpoint().ConfigureAwait(false);
 
         try
         {
@@ -117,7 +117,7 @@ public abstract class BaseRunner : IConfigurationSource, IContext
             //}
 
             //foreach (var t in tasks)
-            //    await Task.WhenAll(tasks);
+            //    await Task.WhenAll(tasks).ConfigureAwait(false);
 
             var elapsed = start.Elapsed;
             var avg = count / elapsed.TotalSeconds;
@@ -128,7 +128,7 @@ public abstract class BaseRunner : IConfigurationSource, IContext
         }
         finally
         {
-            await Session.Close();
+            await Session.Close().ConfigureAwait(false);
         }
     }
 

--- a/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
@@ -20,11 +20,10 @@ abstract class LoopRunner : BaseRunner
     int BatchSize { get; set; } = 16;
     protected abstract Task SendMessage(ISession session);
 
-    protected override Task Start(ISession session)
+    protected override async Task Start(ISession session)
     {
         stopLoop = new CancellationTokenSource();
-        loopTask = Task.Factory.StartNew(() => Loop(session), TaskCreationOptions.LongRunning);
-        return Task.FromResult(0);
+        loopTask = await Task.Factory.StartNew(() => Loop(session), TaskCreationOptions.LongRunning).ConfigureAwait(false);
     }
 
     protected override Task Stop()
@@ -93,6 +92,7 @@ abstract class LoopRunner : BaseRunner
         catch (Exception ex)
         {
             Log.Error("Loop", ex);
+            throw;
         }
     }
 

--- a/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
@@ -45,7 +45,7 @@ abstract class LoopRunner : BaseRunner
         try
         {
             Log.Warn("Sleeping 3,000ms for the instance to purge the queue and process subscriptions. Loop requires the queue to be empty.");
-            await Task.Delay(3000);
+            await Task.Delay(3000).ConfigureAwait(false);
             Log.Info("Starting");
             var start = Stopwatch.StartNew();
             countdownEvent = new CountdownEvent(BatchSize);
@@ -60,7 +60,7 @@ abstract class LoopRunner : BaseRunner
                     countdownEvent.Reset(BatchSize);
                     var batchDuration = Stopwatch.StartNew();
 
-                    await TaskHelper.ParallelFor(BatchSize, () => SendMessage(session));
+                    await TaskHelper.ParallelFor(BatchSize, () => SendMessage(session)).ConfigureAwait(false);
 
                     count += BatchSize;
 

--- a/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
@@ -20,13 +20,14 @@ abstract class LoopRunner : BaseRunner
     int BatchSize { get; set; } = 16;
     protected abstract Task SendMessage(ISession session);
 
-    protected override void Start(ISession session)
+    protected override Task Start(ISession session)
     {
         stopLoop = new CancellationTokenSource();
         loopTask = Task.Factory.StartNew(() => Loop(session), TaskCreationOptions.LongRunning);
+        return Task.FromResult(0);
     }
 
-    protected override void Stop()
+    protected override Task Stop()
     {
         Shutdown = true;
         using (stopLoop)
@@ -37,6 +38,7 @@ abstract class LoopRunner : BaseRunner
                 loopTask.Wait();
             }
         }
+        return Task.FromResult(0);
     }
 
     async Task Loop(ISession session)

--- a/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.V6.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.V6.cs
@@ -9,7 +9,7 @@ partial class SendLocalOneOnOneRunner
         public async Task Handle(Command message, IMessageHandlerContext ctx)
         {
             if (Shutdown) return;
-            await ctx.SendLocal(message);
+            await ctx.SendLocal(message).ConfigureAwait(false);
             System.Threading.Interlocked.Increment(ref Count);
         }
     }

--- a/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.cs
@@ -1,4 +1,5 @@
-﻿using NServiceBus;
+﻿using System.Threading.Tasks;
+using NServiceBus;
 
 /// <summary>
 /// Does a continious test where a configured set of messages are 'seeded' on the
@@ -13,15 +14,15 @@ partial class SendLocalOneOnOneRunner : BaseRunner
 {
     const int seedSize = 1000;
 
-    protected override void Start(ISession session)
+    protected override Task Start(ISession session)
     {
-        TaskHelper.ParallelFor(seedSize, () => session.SendLocal(new Command { Data = Data }))
-            .ConfigureAwait(false).GetAwaiter().GetResult();
+        return TaskHelper.ParallelFor(seedSize, () => session.SendLocal(new Command { Data = Data }));
     }
 
-    protected override void Stop()
+    protected override Task Stop()
     {
         Handler.Shutdown = true;
+        return Task.FromResult(0);
     }
 
     public class Command : ICommand

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/BaseLoop.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/BaseLoop.cs
@@ -20,13 +20,11 @@ abstract class BaseLoop : BaseRunner
     int BatchSize { get; set; } = 16;
     protected abstract Task SendMessage(ISession session);
 
-    protected override Task Start(ISession session)
+    protected override async Task Start(ISession session)
     {
         stopLoop = new CancellationTokenSource();
-        loopTask = Task.Factory.StartNew(() => Loop(session), TaskCreationOptions.LongRunning);
-        return Task.FromResult(0);
+        loopTask = await Task.Factory.StartNew(() => Loop(session), TaskCreationOptions.LongRunning);
     }
-
 
     protected override Task Stop()
     {
@@ -50,6 +48,8 @@ abstract class BaseLoop : BaseRunner
             await Task.Delay(3000);
             Log.Info("Starting");
             start = Stopwatch.StartNew();
+
+
 
 
             while (!Shutdown)

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/BaseLoop.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/BaseLoop.cs
@@ -45,7 +45,7 @@ abstract class BaseLoop : BaseRunner
         try
         {
             Log.Warn("Sleeping 3,000ms for the instance to purge the queue and process subscriptions. Loop requires the queue to be empty.");
-            await Task.Delay(3000);
+            await Task.Delay(3000).ConfigureAwait(false);
             Log.Info("Starting");
             start = Stopwatch.StartNew();
 
@@ -60,7 +60,7 @@ abstract class BaseLoop : BaseRunner
 
                     var batchDuration = Stopwatch.StartNew();
 
-                    await Batch(BatchSize, () => SendMessage(session));
+                    await Batch(BatchSize, () => SendMessage(session)).ConfigureAwait(false);
 
                     count += BatchSize;
 

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/BaseLoop.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/BaseLoop.cs
@@ -20,14 +20,15 @@ abstract class BaseLoop : BaseRunner
     int BatchSize { get; set; } = 16;
     protected abstract Task SendMessage(ISession session);
 
-    protected override void Start(ISession session)
+    protected override Task Start(ISession session)
     {
         stopLoop = new CancellationTokenSource();
         loopTask = Task.Factory.StartNew(() => Loop(session), TaskCreationOptions.LongRunning);
+        return Task.FromResult(0);
     }
 
 
-    protected override void Stop()
+    protected override Task Stop()
     {
         Shutdown = true;
         using (stopLoop)
@@ -38,6 +39,7 @@ abstract class BaseLoop : BaseRunner
                 loopTask.Wait();
             }
         }
+        return Task.FromResult(0);
     }
 
     async Task Loop(ISession session)

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/ForRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/ForRunner.cs
@@ -5,6 +5,6 @@ class ForRunner : SendLoop
 {
     protected override async Task Batch(int count, Func<Task> action)
     {
-        for (var i = 0; i < count; i++) await action();
+        for (var i = 0; i < count; i++) await action().ConfigureAwait(false);
     }
 }

--- a/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V6.cs
+++ b/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V6.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.Performance
             try
             {
                 provider.ConcurrencyInc();
-                await next();
+                await next().ConfigureAwait(false);
                 provider.SuccessInc();
             }
             catch


### PR DESCRIPTION
Fixes:

- Loop task initialization was incorrectly storing the factory start new task instead of the embedded loop task.

Refactorings:

- Locations that used `.GetAwaiter().GetResult()` refactored to async
- All await statements extended with `.ConfigureAwait(false)`
