### PR TITLE
Pubsub issues

### DIFF
--- a/src/PerformanceTests/Common/Program.cs
+++ b/src/PerformanceTests/Common/Program.cs
@@ -13,10 +13,7 @@ namespace Host
     {
         static ILog Log;
 
-        static string endpointName = "PerformanceTests_" + AppDomain.CurrentDomain.FriendlyName
-            .Replace(".exe", string.Empty)
-            .Replace(' ', '_')
-            .Replace('.', '_');
+        static string endpointName = "PerformanceTest";
 
         static int Main()
         {

--- a/src/PerformanceTests/Transport.V5.AzureServiceBus.V6/AzureServiceBusProfile.cs
+++ b/src/PerformanceTests/Transport.V5.AzureServiceBus.V6/AzureServiceBusProfile.cs
@@ -6,8 +6,11 @@ class AzureServiceBusProfile : IProfile
 
     public void Configure(BusConfiguration busConfiguration)
     {
+        busConfiguration.ScaleOut().UseSingleBrokerQueue();
+
         busConfiguration
             .UseTransport<AzureServiceBusTransport>()
             .ConnectionString(connectionstring);
+
     }
 }


### PR DESCRIPTION
Native pubsub got mis configured due to endpoint name differences between x86 / x64 and pubsub broken in V5 due to unsupported / broken scale out default when not using the azure host.