### PR TITLE
Generate test cases based on implementations found

### DIFF
--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/ServiceControlApi.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/ServiceControlApi.cs
@@ -6,6 +6,7 @@
     using System.Net;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
+    using System.Threading.Tasks;
 
     public class ServiceControlApi
     {
@@ -16,11 +17,11 @@
 
         public bool CheckIsAvailable()
         {
-            return Get<object>("") != null;
+            return Get<object>("").Result != null;
         }
 
         // TODO: This was lifted from the SC Acceptance Tests. It may not be appropriate for these tests
-        public T Get<T>(string url) where T : class
+        public async Task<T> Get<T>(string url) where T : class
         {
             var request = (HttpWebRequest)WebRequest.Create($"{rootUri}{url}");
             request.Accept = "application/json";
@@ -28,7 +29,7 @@
             HttpWebResponse response;
             try
             {
-                response = request.GetResponse() as HttpWebResponse;
+                response = await request.GetResponseAsync() as HttpWebResponse;
             }
             catch (WebException ex)
             {

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/ServiceControlFactory.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/ServiceControlFactory.cs
@@ -74,7 +74,6 @@ namespace ServiceControlCompatibilityTests
 
         static void UpdateRuntimeSection(Configuration configuration)
         {
-
             var runtimesection = configuration.GetSection("runtime");
             var runtimeXml = XDocument.Parse(runtimesection.SectionInformation.GetRawXml() ?? "<runtime/>");
 

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/SampleTests.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/SampleTests.cs
@@ -1,24 +1,48 @@
 ﻿namespace ServiceControlCompatibilityTests
 {
     using NUnit.Framework;
+    using System;
+    using System.Linq;
 
     [TestFixture]
     class SampleTests : SqlScTest
     {
         [Test]
-        public void SampleTestA()
+        public async void SampleTestA()
         {
-            var details = ServiceControl.Get<ServiceControlDetails>("");
+            var details = await ServiceControl.Get<ServiceControlDetails>("");
 
             Assert.Pass($"{TestContext.CurrentContext.Test.Name} - {details.Description}");
         }
 
         [Test]
-        public void SampleTestB()
+        public async void SampleTestB()
         {
-            var details = ServiceControl.Get<ServiceControlDetails>("");
+            var details = await ServiceControl.Get<ServiceControlDetails>("");
 
             Assert.Pass($"{TestContext.CurrentContext.Test.Name} - {details.Description}");
+        }
+
+        [TestCaseSource(nameof(TransportTests))]
+        public void TransportTest(Type transport)
+        {
+            RunTest(ActivateInstanceOfTransportDetail(transport));
+        }
+
+        public void RunTest(ITransportDetails transport)
+        {
+            StartServiceControl(transport);
+
+            Assert.Pass();
+        }
+
+        static object[] TransportTests()
+        {
+            var transports = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(assembly => assembly.GetTypes())
+                .Where(type => type.GetInterfaces().Any(i => i == (typeof(ITransportDetails))));
+
+            return transports.ToArray();
         }
 
         class ServiceControlDetails

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/ServiceControlCompatibilityTests.csproj
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/ServiceControlCompatibilityTests.csproj
@@ -67,6 +67,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Related To https://github.com/Particular/PlatformDevelopment/issues/833

Builds on top of https://github.com/Particular/EndToEnd/pull/146

* Changed the web requests to be async
* Generate the test cases based on the implementations if `ITransportDetails` in the assemblies
* Create an activator `Func<T>` to cater for different types of `ITransportDetails`

Depending on the differences between the versions of the transports, we may need to separate the implementations of the `ITransportDetails` into separate projects and have different ones for each version of the transports. (not in scope for now?)

ping @mikeminutillo @ramonsmits @gbiellem @HEskandari 