### PR TITLE
PerfTest Logging configuration

### DIFF
--- a/src/PerformanceTests/NServiceBus5/App.Release.config
+++ b/src/PerformanceTests/NServiceBus5/App.Release.config
@@ -8,7 +8,7 @@
       <logger xdt:Transform="RemoveAll" />
       <logger xdt:Transform="Insert" name="Statistics" minlevel="Debug" writeTo="splunk" />
       <logger xdt:Transform="Insert" name="Environment" minlevel="Debug" writeTo="splunk" />
-      <logger xdt:Transform="Insert" name="*" minlevel="Warn" writeTo="file" />
+      <logger xdt:Transform="Insert" name="*" minlevel="Info" writeTo="file" />
     </rules>
   </nlog>
   <appSettings>

--- a/src/PerformanceTests/NServiceBus6/App.Release.config
+++ b/src/PerformanceTests/NServiceBus6/App.Release.config
@@ -8,7 +8,7 @@
       <logger xdt:Transform="RemoveAll" />
       <logger xdt:Transform="Insert" name="Statistics" minlevel="Debug" writeTo="splunk" />
       <logger xdt:Transform="Insert" name="Environment" minlevel="Debug" writeTo="splunk" />
-      <logger xdt:Transform="Insert" name="*" minlevel="Warn" writeTo="file" />
+      <logger xdt:Transform="Insert" name="*" minlevel="Info" writeTo="file" />
     </rules>
   </nlog>
   <appSettings>

--- a/src/PerformanceTests/NServiceBus6/App.config
+++ b/src/PerformanceTests/NServiceBus6/App.config
@@ -15,7 +15,6 @@
       <target name="console" xsi:type="ColoredConsole" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
     </targets>
     <rules>
-        <logger name="NServiceBus.AzureServiceBus.DefaultOutgoingBatchRouter" maxlevel="Info" final="true" />
         <logger name="*" minlevel="Info" writeTo="file,trace,console" />
     </rules>
   </nlog>


### PR DESCRIPTION
- Log level set to Info for file logging as a failed test on the build server doesn't give any clue what happened.
- Removed log rule for ASB as this log level issue is resolved.