### PR TITLE
Multi-Instance SQL Transport support for platform compatibility tests

### DIFF
--- a/src/PlatformCompatibilityTests/ASB/ASBForwardingTopologyTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/ASB/ASBForwardingTopologyTransportDetails.cs
@@ -15,6 +15,8 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "AzureServiceBus";
 
+        public void Initialize() { }
+
         public void ApplyTo(Configuration configuration)
         {
             configuration.ConnectionStrings.ConnectionStrings.Set("NServiceBus/Transport", connectionString);
@@ -22,12 +24,13 @@ namespace ServiceControlCompatibilityTests
             settings.Set(SettingsList.TransportType, TransportTypeName);
         }
 
-        public void ConfigureEndpoint(EndpointConfiguration endpointConfig)
+        public void ConfigureEndpoint(string endpointName, EndpointConfiguration endpointConfig)
         {
             endpointConfig.UseTransport<AzureServiceBusTransport>()
                 .ConnectionString(connectionString)
                 .UseTopology<ForwardingTopology>();
         }
+
 
         string connectionString;
     }

--- a/src/PlatformCompatibilityTests/ASB/ASBForwardingTopologyTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/ASB/ASBForwardingTopologyTransportDetails.cs
@@ -4,6 +4,8 @@ using NServiceBus.AzureServiceBus;
 
 namespace ServiceControlCompatibilityTests
 {
+    using System.Threading.Tasks;
+
     public class ASBForwardingTopologyTransportDetails : ITransportDetails
     {
         const string TransportTypeName = "NServiceBus.AzureServiceBusTransport, NServiceBus.Azure.Transports.WindowsAzureServiceBus";
@@ -15,7 +17,10 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "AzureServiceBus";
 
-        public void Initialize() { }
+        public Task Initialize()
+        {
+            return Task.FromResult(0);
+        }
 
         public void ApplyTo(Configuration configuration)
         {

--- a/src/PlatformCompatibilityTests/ASQ/ASQTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/ASQ/ASQTransportDetails.cs
@@ -3,6 +3,8 @@ using NServiceBus;
 
 namespace ServiceControlCompatibilityTests
 {
+    using System.Threading.Tasks;
+
     public class ASQTransportDetails : ITransportDetails
     {
         const string TransportTypeName = "NServiceBus.AzureStorageQueueTransport, NServiceBus.Azure.Transports.WindowsAzureStorageQueues";
@@ -14,7 +16,10 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "AzureStorageQueue";
 
-        public void Initialize() { }
+        public Task Initialize()
+        {
+            return Task.FromResult(0);
+        }
 
         public void ApplyTo(Configuration configuration)
         {

--- a/src/PlatformCompatibilityTests/ASQ/ASQTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/ASQ/ASQTransportDetails.cs
@@ -14,6 +14,8 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "AzureStorageQueue";
 
+        public void Initialize() { }
+
         public void ApplyTo(Configuration configuration)
         {
             configuration.ConnectionStrings.ConnectionStrings.Set("NServiceBus/Transport", connectionString);
@@ -21,7 +23,7 @@ namespace ServiceControlCompatibilityTests
             settings.Set(SettingsList.TransportType, TransportTypeName);
         }
 
-        public void ConfigureEndpoint(EndpointConfiguration endpointConfig)
+        public void ConfigureEndpoint(string endpointName, EndpointConfiguration endpointConfig)
         {
             endpointConfig.UseTransport<AzureStorageQueueTransport>()
                 .ConnectionString(connectionString);

--- a/src/PlatformCompatibilityTests/RabbitMQ/RabbitMqTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/RabbitMQ/RabbitMqTransportDetails.cs
@@ -3,6 +3,8 @@ using NServiceBus;
 
 namespace ServiceControlCompatibilityTests
 {
+    using System.Threading.Tasks;
+
     public class RabbitMQTransportDetails : ITransportDetails
     {
         const string TransportTypeName = "NServiceBus.RabbitMQTransport, NServiceBus.Transports.RabbitMQ";
@@ -14,7 +16,10 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "RabbitMQ";
 
-        public void Initialize() { }
+        public Task Initialize()
+        {
+            return Task.FromResult(0);
+        }
 
         public void ApplyTo(Configuration configuration)
         {

--- a/src/PlatformCompatibilityTests/RabbitMQ/RabbitMqTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/RabbitMQ/RabbitMqTransportDetails.cs
@@ -14,6 +14,8 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "RabbitMQ";
 
+        public void Initialize() { }
+
         public void ApplyTo(Configuration configuration)
         {
             configuration.ConnectionStrings.ConnectionStrings.Set("NServiceBus/Transport", connectionString);
@@ -21,7 +23,7 @@ namespace ServiceControlCompatibilityTests
             settings.Set(SettingsList.TransportType, TransportTypeName);
         }
 
-        public void ConfigureEndpoint(EndpointConfiguration endpointConfig)
+        public void ConfigureEndpoint(string endpointName, EndpointConfiguration endpointConfig)
         {
             endpointConfig.UseTransport<RabbitMQTransport>()
                 .ConnectionString(connectionString);

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/EndpointFactory.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/EndpointFactory.cs
@@ -33,7 +33,7 @@ namespace ServiceControlCompatibilityTests
             config.SendFailedMessagesTo("error");
             config.AuditProcessedMessagesTo("audit");
 
-            transportDetails.ConfigureEndpoint(config);
+            transportDetails.ConfigureEndpoint(endpointDetails.Name, config);
 
             return new EndpointProxy(endpointDetails.Name, await Endpoint.Create(config));
         }

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/Msmq/MsmqTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/Msmq/MsmqTransportDetails.cs
@@ -11,13 +11,15 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "Msmq";
 
+        public void Initialize() { }
+
         public void ApplyTo(Configuration configuration)
         {
             var settings = configuration.AppSettings.Settings;
             settings.Set(SettingsList.TransportType, TransportTypeName);
         }
 
-        public void ConfigureEndpoint(EndpointConfiguration endpointConfig)
+        public void ConfigureEndpoint(string endpointName, EndpointConfiguration endpointConfig)
         {
             endpointConfig.UseTransport<MsmqTransport>();
 

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/Msmq/MsmqTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/Msmq/MsmqTransportDetails.cs
@@ -3,6 +3,8 @@ using NServiceBus;
 
 namespace ServiceControlCompatibilityTests
 {
+    using System.Threading.Tasks;
+
     // Todo: Potentially move this out to a separate project
     // so we don't take a hard dependency on NServiceBus.SqlServer
     class MsmqTransportDetails : ITransportDetails
@@ -11,7 +13,10 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "Msmq";
 
-        public void Initialize() { }
+        public Task Initialize()
+        {
+            return Task.FromResult(0);
+        }
 
         public void ApplyTo(Configuration configuration)
         {

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/ServiceControlTest.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/ServiceControlTest.cs
@@ -6,6 +6,8 @@
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
+
     abstract class SqlScTest
     {
         Dictionary<Type, Func<ITransportDetails>> transportDetailActivations = new Dictionary<Type, Func<ITransportDetails>>
@@ -23,7 +25,7 @@
             }
         };
 
-        protected IEndpointFactory StartUp(string testName, Type transportDetailsType, Action<IDictionary<string, string>> fillInEndpointMappings = null)
+        protected async Task<IEndpointFactory> StartUp(string testName, Type transportDetailsType, Action<IDictionary<string, string>> fillInEndpointMappings = null)
         {
             var testId = $"{testName}_{transportDetailsType.Name.Replace("TransportDetails", "")}";
             Console.WriteLine($"Starting test {testId}");
@@ -34,7 +36,7 @@
 
             (transportDetails as IAcceptEndpointMapping)?.AcceptEndpointMapping(endpointMappings);
 
-            transportDetails.Initialize();
+            await transportDetails.Initialize();
             
             serviceControl = StartServiceControl(testId, transportDetails);
 

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/ServiceControlTest.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/Infrastructure/ServiceControlTest.cs
@@ -15,14 +15,27 @@
             { typeof(RabbitMQTransportDetails), () => new RabbitMQTransportDetails("host=localhost") },
             { typeof(ASBForwardingTopologyTransportDetails), () => new ASBForwardingTopologyTransportDetails(Environment.GetEnvironmentVariable("AzureServiceBus.ConnectionString")) },
             { typeof(ASQTransportDetails), () => new ASQTransportDetails(Environment.GetEnvironmentVariable("AzureStorageQueueTransport.ConnectionString")) },
+            {
+                typeof(MultiInstanceSqlTransportDetails), () => 
+                    new MultiInstanceSqlTransportDetails("Data Source=.\\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True")
+                        .WithServer(ServerA, $"Data Source=.\\SQLEXPRESS;Initial Catalog={ServerA};Integrated Security=True")
+                        .WithServer(ServerB, $"Data Source=.\\SQLEXPRESS;Initial Catalog={ServerB};Integrated Security=True")
+            }
         };
 
-        protected IEndpointFactory StartUp(string testName, Type transportDetailsType)
+        protected IEndpointFactory StartUp(string testName, Type transportDetailsType, Action<IDictionary<string, string>> fillInEndpointMappings = null)
         {
             var testId = $"{testName}_{transportDetailsType.Name.Replace("TransportDetails", "")}";
             Console.WriteLine($"Starting test {testId}");
-            //Console.WriteLine($"Creating test for {transportDetailsType.Name}");
             var transportDetails = ActivateInstanceOfTransportDetail(transportDetailsType);
+
+            var endpointMappings = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            fillInEndpointMappings?.Invoke(endpointMappings);
+
+            (transportDetails as IAcceptEndpointMapping)?.AcceptEndpointMapping(endpointMappings);
+
+            transportDetails.Initialize();
+            
             serviceControl = StartServiceControl(testId, transportDetails);
 
             var endpointFactory = new EndpointFactory(transportDetails);
@@ -78,5 +91,8 @@
 
         ServiceControlInstance serviceControl;
         protected ServiceControlApi ServiceControl => serviceControl.Api;
+
+        protected const string ServerA = "ServerA";
+        protected const string ServerB = "ServerB";
     }
 }

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/SuccessfulRetryTests.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/SuccessfulRetryTests.cs
@@ -10,14 +10,14 @@
     {
         [TestCaseSource(nameof(AllTransports))]
         [Timeout(300000)]
-        public Task Can_successfully_retry_a_failed_message(Type transportDetailType)
+        public async Task Can_successfully_retry_a_failed_message(Type transportDetailType)
         {
-            var endpointFactory = StartUp("Retry", transportDetailType, map =>
+            var endpointFactory = await StartUp("Retry", transportDetailType, map =>
             {
                 map[SenderEndpointName] = ServerA;
                 map[ProcessorEndpointName] = ServerB;
             });
-            return RunTest(endpointFactory);
+            await RunTest(endpointFactory);
         }
 
         async Task RunTest(IEndpointFactory endpointFactory)

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/SuccessfulRetryTests.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/SuccessfulRetryTests.cs
@@ -12,7 +12,11 @@
         [Timeout(300000)]
         public Task Can_successfully_retry_a_failed_message(Type transportDetailType)
         {
-            var endpointFactory = StartUp("Retry", transportDetailType);
+            var endpointFactory = StartUp("Retry", transportDetailType, map =>
+            {
+                map[SenderEndpointName] = ServerA;
+                map[ProcessorEndpointName] = ServerB;
+            });
             return RunTest(endpointFactory);
         }
 
@@ -20,8 +24,8 @@
         {
             var testContext = new TestContext();
 
-            var sender = await endpointFactory.CreateEndpoint("Sender");
-            var processor = await endpointFactory.CreateEndpoint(new EndpointDetails("Processor").With<TestMessageHandler>().With(testContext));
+            var sender = await endpointFactory.CreateEndpoint(SenderEndpointName);
+            var processor = await endpointFactory.CreateEndpoint(new EndpointDetails(ProcessorEndpointName).With<TestMessageHandler>().With(testContext));
 
             testContext.ShouldFail = true;
             var failingMessageId = await sender.Send(processor, new TestMessage());
@@ -33,6 +37,9 @@
 
             Assert.IsTrue(handled, "Did not process the retry successfully within the time limit");
         }
+
+        const string SenderEndpointName = "Sender";
+        const string ProcessorEndpointName = "Processor";
     }
 
     class TestMessage : ICommand

--- a/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/When_retrying_a_message_and_the_handler_has_a_reply.cs
+++ b/src/PlatformCompatibilityTests/ServiceControlCompatibilityTests/When_retrying_a_message_and_the_handler_has_a_reply.cs
@@ -10,14 +10,14 @@ namespace ServiceControlCompatibilityTests
     {
         [TestCaseSource(nameof(AllTransports))]
         [Timeout(300000)]
-        public Task When_successfully_retry_a_failed_message_with_reply_it_gets_routed_back_to_sender(Type transportDetailsDType)
+        public async Task When_successfully_retry_a_failed_message_with_reply_it_gets_routed_back_to_sender(Type transportDetailsDType)
         {
-            var endpointFactory = StartUp("Retry-with-Reply", transportDetailsDType, mapping =>
+            var endpointFactory = await StartUp("Retry-with-Reply", transportDetailsDType, mapping =>
             {
                 mapping[SenderEndpointName] = ServerA;
                 mapping[ResponderEndpointName] = ServerB;
             });
-            return RunReplyTest(endpointFactory);
+            await RunReplyTest(endpointFactory);
         }
 
         async Task RunReplyTest(IEndpointFactory endpointFactory)

--- a/src/PlatformCompatibilityTests/Sql/MultiInstanceSqlTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/Sql/MultiInstanceSqlTransportDetails.cs
@@ -1,0 +1,114 @@
+﻿namespace ServiceControlCompatibilityTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Configuration;
+    using System.Data.SqlClient;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Transport.SQLServer;
+
+    public class MultiInstanceSqlTransportDetails : SqlTransportDetails, IAcceptEndpointMapping
+    {
+        public MultiInstanceSqlTransportDetails(string defaultConnectionString) : base(defaultConnectionString) { }
+
+        public void AcceptEndpointMapping(IDictionary<string, string> endpointMapping)
+        {
+            _endpointMapping = endpointMapping;
+        }
+
+        public MultiInstanceSqlTransportDetails WithServer(string tag, string serverConnectionString)
+        {
+            _connectionStringMapping[tag] = serverConnectionString;
+            return this;
+        }
+
+        public override void Initialize()
+        {
+            Console.WriteLine("Creating databases");
+            Task.WhenAll(_connectionStringMapping.Values.Select(EnsureDatabaseExists));
+        }
+
+        static async Task EnsureDatabaseExists(string connectionString)
+        {
+            var builder = new SqlConnectionStringBuilder(connectionString);
+            var databaseName = builder.InitialCatalog;
+            builder.InitialCatalog = "master";
+
+            Console.WriteLine($"Creating Database [{databaseName}]");
+
+            SqlConnection connection = null;
+
+            try
+            {
+                connection = new SqlConnection(builder.ToString());
+                await connection.OpenAsync().ConfigureAwait(false);
+
+                var cmd = new SqlCommand($"if not exists(select * from sys.databases where name = '{databaseName}') create database [{databaseName}]", connection);
+                await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+                Console.WriteLine($"[{databaseName}] Created");
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine($"Exception creating database [{databaseName}]: {exception}");
+            }
+            finally
+            {
+                connection?.Close();
+            }
+        }
+
+        public override void ApplyTo(Configuration configuration)
+        {
+            base.ApplyTo(configuration);
+            configuration.AppSettings.Settings.Set(SettingsList.EnableDTC, true.ToString());
+            foreach (var mapping in _endpointMapping)
+            {
+                configuration.ConnectionStrings.ConnectionStrings.Set($"NServiceBus/Transport/{mapping.Key}", GetConnectionString(mapping.Key));
+            }
+        }
+
+        public override void ConfigureEndpoint(string endpointName, EndpointConfiguration endpointConfig)
+        {
+            endpointConfig.PurgeOnStartup(true);
+
+            var transport = endpointConfig.UseTransport<SqlServerTransport>();
+
+            transport.ConnectionString(GetConnectionString(endpointName));
+
+#pragma warning disable 618
+            transport.EnableLegacyMultiInstanceMode(async transportAddress =>
+#pragma warning restore 618
+            {
+                var connection = new SqlConnection(GetConnectionString(transportAddress));
+                await connection.OpenAsync().ConfigureAwait(false);
+                return connection;
+            });
+        }
+
+        string GetConnectionString(string endpointNameOrTransportAddress)
+        {
+            var endpointName = endpointNameOrTransportAddress.Replace("@[dbo]", "");
+
+            var instanceConnectionString = connectionString;
+
+            string instanceTag;
+            if (!_endpointMapping.TryGetValue(endpointName, out instanceTag))
+            {
+                return instanceConnectionString;
+            }
+
+            if (_connectionStringMapping.TryGetValue(instanceTag, out instanceConnectionString))
+            {
+                return instanceConnectionString;
+            }
+
+            throw new Exception($"{endpointNameOrTransportAddress} gets converted to Endpoint {endpointName} which gets mapped to {instanceTag} but there is no corresponding connectionString for {instanceTag}");
+        }
+
+        IDictionary<string, string> _endpointMapping;
+        IDictionary<string, string> _connectionStringMapping = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+    }
+}

--- a/src/PlatformCompatibilityTests/Sql/MultiInstanceSqlTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/Sql/MultiInstanceSqlTransportDetails.cs
@@ -24,10 +24,11 @@
             return this;
         }
 
-        public override void Initialize()
+        public override async Task Initialize()
         {
             Console.WriteLine("Creating databases");
-            Task.WhenAll(_connectionStringMapping.Values.Select(EnsureDatabaseExists));
+            await Task.WhenAll(_connectionStringMapping.Values.Select(EnsureDatabaseExists)).ConfigureAwait(false);
+            Console.WriteLine("Databases created");
         }
 
         static async Task EnsureDatabaseExists(string connectionString)

--- a/src/PlatformCompatibilityTests/Sql/Sql.csproj
+++ b/src/PlatformCompatibilityTests/Sql/Sql.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MultiInstanceSqlTransportDetails.cs" />
     <Compile Include="SqlTransportDetails.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PlatformCompatibilityTests/Sql/SqlTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/Sql/SqlTransportDetails.cs
@@ -3,6 +3,8 @@ using NServiceBus;
 
 namespace ServiceControlCompatibilityTests
 {
+    using System.Threading.Tasks;
+
     public class SqlTransportDetails : ITransportDetails
     {
         const string TransportTypeName = "NServiceBus.SqlServerTransport, NServiceBus.Transports.SQLServer";
@@ -14,7 +16,10 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "SQLServer";
 
-        public virtual void Initialize() { }
+        public virtual Task Initialize()
+        {
+            return Task.FromResult(0);
+        }
 
         public virtual void ApplyTo(Configuration configuration)
         {

--- a/src/PlatformCompatibilityTests/Sql/SqlTransportDetails.cs
+++ b/src/PlatformCompatibilityTests/Sql/SqlTransportDetails.cs
@@ -14,14 +14,16 @@ namespace ServiceControlCompatibilityTests
 
         public string TransportName => "SQLServer";
 
-        public void ApplyTo(Configuration configuration)
+        public virtual void Initialize() { }
+
+        public virtual void ApplyTo(Configuration configuration)
         {
             configuration.ConnectionStrings.ConnectionStrings.Set("NServiceBus/Transport", connectionString);
             var settings = configuration.AppSettings.Settings;
             settings.Set(SettingsList.TransportType, TransportTypeName);
         }
 
-        public void ConfigureEndpoint(EndpointConfiguration endpointConfig)
+        public virtual void ConfigureEndpoint(string endpointName, EndpointConfiguration endpointConfig)
         {
             endpointConfig.UseTransport<SqlServerTransport>()
                 .ConnectionString(connectionString);
@@ -29,6 +31,6 @@ namespace ServiceControlCompatibilityTests
             endpointConfig.PurgeOnStartup(true);
         }
 
-        string connectionString;
+        protected string connectionString;
     }
 }

--- a/src/PlatformCompatibilityTests/TestFramework/IAcceptEndpointMapping.cs
+++ b/src/PlatformCompatibilityTests/TestFramework/IAcceptEndpointMapping.cs
@@ -1,0 +1,9 @@
+﻿namespace ServiceControlCompatibilityTests
+{
+    using System.Collections.Generic;
+
+    public interface IAcceptEndpointMapping
+    {
+        void AcceptEndpointMapping(IDictionary<string, string> endpointMapping);
+    }
+}

--- a/src/PlatformCompatibilityTests/TestFramework/ITransportDetails.cs
+++ b/src/PlatformCompatibilityTests/TestFramework/ITransportDetails.cs
@@ -7,6 +7,7 @@ namespace ServiceControlCompatibilityTests
     {
         string TransportName { get; }
         void ApplyTo(Configuration configuration);
-        void ConfigureEndpoint(EndpointConfiguration endpointConfig);
+        void ConfigureEndpoint(string endpointName, EndpointConfiguration endpointConfig);
+        void Initialize();
     }
 }

--- a/src/PlatformCompatibilityTests/TestFramework/ITransportDetails.cs
+++ b/src/PlatformCompatibilityTests/TestFramework/ITransportDetails.cs
@@ -2,12 +2,13 @@ namespace ServiceControlCompatibilityTests
 {
     using NServiceBus;
     using System.Configuration;
+    using System.Threading.Tasks;
 
     public interface ITransportDetails
     {
         string TransportName { get; }
         void ApplyTo(Configuration configuration);
         void ConfigureEndpoint(string endpointName, EndpointConfiguration endpointConfig);
-        void Initialize();
+        Task Initialize();
     }
 }

--- a/src/PlatformCompatibilityTests/TestFramework/SettingsList.cs
+++ b/src/PlatformCompatibilityTests/TestFramework/SettingsList.cs
@@ -18,5 +18,6 @@
         public static SettingInfo AuditLogQueue = new SettingInfo { Name = "ServiceBus/AuditLogQueue" };
         public static SettingInfo AuditRetentionPeriod = new SettingInfo { Name = "ServiceControl/AuditRetentionPeriod", SupportedFrom = new Version(1, 12, 1) };
         public static SettingInfo ErrorRetentionPeriod = new SettingInfo { Name = "ServiceControl/ErrorRetentionPeriod", SupportedFrom = new Version(1, 12, 1) };
+        public static SettingInfo EnableDTC = new SettingInfo { Name = "ServiceControl/EnableDTC", SupportedFrom = new Version(1, 19, 0) };
     }
 }

--- a/src/PlatformCompatibilityTests/TestFramework/TestFramework.csproj
+++ b/src/PlatformCompatibilityTests/TestFramework/TestFramework.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigurationSectionExtensions.cs" />
+    <Compile Include="IAcceptEndpointMapping.cs" />
     <Compile Include="ITransportDetails.cs" />
     <Compile Include="SettingInfo.cs" />
     <Compile Include="SettingsList.cs" />


### PR DESCRIPTION
Each test may now provide a mapping from endpoint name to some kind of tag (in this case I've just used logical server name). It is up to the transport to map that to something useful if it wants to.

Multi-Instance SQL Transport uses the tag to map each endpoint to a specific connection string. 