### PR TITLE
Setting different Categories for Test Fixtures 

### DIFF
--- a/src/PerformanceTests/Tests/Categories/AuditOnVsOffFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/AuditOnVsOffFixture.cs
@@ -7,7 +7,7 @@ using Variables;
 namespace Categories
 {
 
-    [TestFixture(Description = "Audit forwarding On / Off", Category = "Performance")]
+    [TestFixture(Description = "Audit forwarding On / Off", Category = "AuditOnVsOff")]
     public class AuditOnVsOffFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/AzureFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/AzureFixture.cs
@@ -7,7 +7,7 @@ namespace Tests.Categories
     using Permutations;
     using Variables;
 
-    [TestFixture(Description = "Persisters", Category = "Performance"), Explicit]
+    [TestFixture(Description = "Persisters", Category = "Azure"), Explicit]
     public class AzureFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/DistributorFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/DistributorFixture.cs
@@ -5,7 +5,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "Distributor distribution", Category = "Performance")]
+    [TestFixture(Description = "Distributor distribution", Category = "Distributor")]
     [Explicit]
     public class DistributorFixture : Base
     {

--- a/src/PerformanceTests/Tests/Categories/MsmqFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/MsmqFixture.cs
@@ -5,7 +5,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "MSMQ", Category = "Performance")]
+    [TestFixture(Description = "MSMQ", Category = "Msmq")]
     public class MsmqFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/OutboxVsDtcFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/OutboxVsDtcFixture.cs
@@ -6,7 +6,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "Outbox vs DTC", Category = "Performance")]
+    [TestFixture(Description = "Outbox vs DTC", Category = "OutboxVsDtc")]
     public class OutboxVsDtcFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/PersistersFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/PersistersFixture.cs
@@ -6,7 +6,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "Persisters", Category = "Performance")]
+    [TestFixture(Description = "Persisters", Category = "Persisters")]
     public class PersistersFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/PlatformFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/PlatformFixture.cs
@@ -6,7 +6,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "Platform x86/x64, gc client/server", Category = "Performance")]
+    [TestFixture(Description = "Platform x86/x64, gc client/server", Category = "Platform")]
     public class PlatformFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/RavenDBFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/RavenDBFixture.cs
@@ -5,7 +5,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "RavenDB", Category = "Performance"), Explicit]
+    [TestFixture(Description = "RavenDB", Category = "RavenDBConcurrency"), Explicit]
     public class RavenDBConcurrencyForV6Fixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/ResourceUtilizationFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/ResourceUtilizationFixture.cs
@@ -6,7 +6,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "Resources utilization", Category = "Performance")]
+    [TestFixture(Description = "Resources utilization", Category = "ResourceUtilization")]
     public class ResourceUtilizationFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/SendThroughputFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/SendThroughputFixture.cs
@@ -6,7 +6,7 @@ using Variables;
 
 namespace Categories
 { 
-    [TestFixture(Description = "Send throughput", Category = "Performance")]
+    [TestFixture(Description = "Send throughput", Category = "SendThroughput")]
     public class SendThroughputFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/SenderSideFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/SenderSideFixture.cs
@@ -5,7 +5,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "Sender-side distribution", Category = "Performance")]
+    [TestFixture(Description = "Sender-side distribution", Category = "SenderSide")]
     [Explicit]
     public class SenderSideFixture : Base
     {

--- a/src/PerformanceTests/Tests/Categories/SerializerFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/SerializerFixture.cs
@@ -6,7 +6,7 @@ using Variables;
 namespace Categories
 {
 
-    [TestFixture(Description = "Serializer differences", Category = "Performance")]
+    [TestFixture(Description = "Serializer differences", Category = "Serializer")]
     public class SerializerFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/SqlTransportFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/SqlTransportFixture.cs
@@ -6,7 +6,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "Transports", Category = "Performance"), Explicit]
+    [TestFixture(Description = "Transports", Category = "SqlTransports"), Explicit]
     public class SqlTransportsFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/TransactionModesFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/TransactionModesFixture.cs
@@ -6,7 +6,7 @@ using Variables;
 
 namespace Categories
 {
-    [TestFixture(Description = "Transaction Modes", Category = "Performance")]
+    [TestFixture(Description = "Transaction Modes", Category = "TransactionModes")]
     public class TransactionModesFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/TransportsFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/TransportsFixture.cs
@@ -6,7 +6,7 @@ namespace Categories
     using Tests.Permutations;
     using Variables;
 
-    [TestFixture(Description = "Transports", Category = "Performance")]
+    [TestFixture(Description = "Transports", Category = "Transports")]
     public class TransportsFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Utils/Permutations/PermutationGenerator.cs
+++ b/src/PerformanceTests/Utils/Permutations/PermutationGenerator.cs
@@ -36,7 +36,7 @@ namespace Tests.Permutations
                     TransactionMode = TransactionMode,
                     AuditMode = AuditMode,
                     ConcurrencyLevel = ConcurrencyLevel,
-                    ScaleOut = ScaleOut,
+                    ScaleOut = ScaleOut, 
 
                     Code = string.Empty
                      + (permutations.Versions.Length > 1 ? Version + Separator : string.Empty)


### PR DESCRIPTION
to enable running tests in smaller groups on builder

This step would allow to create separate build configuration running only subset of tests like:
- Transports
- Permutations 
  etc.

By doing that we would allow to run only subset of test: only Transports. And after each step we would get full feedback with artifacts etc.

cc: @Particular/endtoend-maintainers 
