### PR TITLE
Outbox fix for Outbox vs DTC fixture and logging improvements

### DIFF
--- a/src/PerformanceTests/Common/Common.Data.projitems
+++ b/src/PerformanceTests/Common/Common.Data.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)IContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)INeedContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IProfile.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)OutboxProfile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PerformanceCounters.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Program.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReflectionExtensions.cs" />

--- a/src/PerformanceTests/Common/OutboxProfile.cs
+++ b/src/PerformanceTests/Common/OutboxProfile.cs
@@ -1,0 +1,20 @@
+#if Version6
+using Configuration = NServiceBus.EndpointConfiguration;
+#else
+using Configuration = NServiceBus.BusConfiguration;
+#endif
+
+using NServiceBus;
+using Tests.Permutations;
+using Variables;
+
+class OutboxProfile : IProfile, INeedPermutation
+{
+    public Permutation Permutation { get; set; }
+
+    public void Configure(Configuration cfg)
+    {
+        if (Permutation.OutboxMode == Outbox.On) cfg.EnableOutbox();
+    }
+
+}

--- a/src/PerformanceTests/Common/Program.cs
+++ b/src/PerformanceTests/Common/Program.cs
@@ -26,9 +26,7 @@ namespace Host
 
             DebugAttacher.AttachDebuggerToVisualStudioProcessFromCommandLineParameter();
 
-            AppDomain.CurrentDomain.FirstChanceException += (o, ea) => { Log.Debug("FirstChanceException", ea.Exception); };
-            AppDomain.CurrentDomain.UnhandledException += (o, ea) => { Log.Error("UnhandledException", ea.ExceptionObject as Exception); };
-
+            InitAppDomainEventLogging();
             CheckPowerPlan();
             CheckIfWindowsDefenderIsRunning();
 
@@ -161,6 +159,20 @@ namespace Host
             {
                 Log.Debug("Powerplan check failed, ignoring", ex);
             }
+        }
+
+        static void InitAppDomainEventLogging()
+        {
+            var firstChanceLog = LogManager.GetLogger("FirstChanceException");
+            var unhandledLog = LogManager.GetLogger("UnhandledException");
+            var domain = AppDomain.CurrentDomain;
+
+            domain.FirstChanceException += (o, ea) => { firstChanceLog.Debug(ea.Exception.Message, ea.Exception); };
+            domain.UnhandledException += (o, ea) =>
+            {
+                var exception = ea.ExceptionObject as Exception;
+                if (exception != null) unhandledLog.Error(exception.Message, exception);
+            };
         }
     }
 }

--- a/src/PerformanceTests/NServiceBus5/App.config
+++ b/src/PerformanceTests/NServiceBus5/App.config
@@ -28,6 +28,7 @@
     <add key="NServiceBus/Persistence/NHibernate/dialect" value="NHibernate.Dialect.MsSql2012Dialect" />
     <add key="Distributor" value="Master" />
     <add key="NServiceBus/Persistence/NHibernate/default_schema" value="V5" />
+    <add key="NServiceBus/Outbox" value="true"/>
   </appSettings>
 
   <MessageForwardingInCaseOfFaultConfig ErrorQueue="error" />

--- a/src/PerformanceTests/NServiceBus6/App.config
+++ b/src/PerformanceTests/NServiceBus6/App.config
@@ -27,6 +27,7 @@
     <add key="NServiceBus/Persistence/NHibernate/dialect" value="NHibernate.Dialect.MsSql2012Dialect" />
     <add key="Distributor" value="Master" />
     <add key="NServiceBus/Persistence/NHibernate/default_schema" value="V6" />
+    <add key="NServiceBus/Outbox" value="true"/>
   </appSettings>
 
   <MessageForwardingInCaseOfFaultConfig ErrorQueue="error" />

--- a/src/PerformanceTests/Tests/Categories/OutboxVsDtcFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/OutboxVsDtcFixture.cs
@@ -24,8 +24,8 @@ namespace Categories
                 Serializers = new[] { Serialization.Json, },
                 MessageSizes = (MessageSize[])Enum.GetValues(typeof(MessageSize)),
                 OutboxModes = (Outbox[])Enum.GetValues(typeof(Outbox)),
-                TransactionMode = new[] {TransactionMode.Transactional, TransactionMode.Receive, }
-            });
+                TransactionMode = new[] { TransactionMode.Transactional, TransactionMode.Atomic, }
+            }, p => p.OutboxMode == Outbox.Off && p.TransactionMode == TransactionMode.Transactional || p.OutboxMode == Outbox.On && p.TransactionMode != TransactionMode.Transactional);
         }
     }
 }

--- a/src/PerformanceTests/Utils/Permutations/PermutationGenerator.cs
+++ b/src/PerformanceTests/Utils/Permutations/PermutationGenerator.cs
@@ -1,5 +1,6 @@
 namespace Tests.Permutations
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -7,7 +8,7 @@ namespace Tests.Permutations
     {
         static readonly string Separator = "~";
 
-        public static IEnumerable<Permutation> Generate(Permutations permutations)
+        public static IEnumerable<Permutation> Generate(Permutations permutations, Func<Permutation, bool> filter = null)
         {
             var items =
                 from Version in permutations.Versions
@@ -52,6 +53,9 @@ namespace Tests.Permutations
                      + (permutations.ConcurrencyLevels.Length > 1 ? ConcurrencyLevel + Separator : string.Empty)
                      + (permutations.ScaleOuts.Length > 1 ? ScaleOut + Separator : string.Empty)
                 };
+
+            if (filter != null) items = items.Where(filter);
+
             return items
                 .OrderBy(x => x.Code);
         }


### PR DESCRIPTION
- Fix for Outbox vs DTC fixture, outbox was previously not enabled in permutations
- Filtering Outbox vs DTC fixture permutations, only do DTC and no outbox and no DTC with outbox
- First chance exception and unhandled exception event logging improvement