### PR TITLE
Loop runner now using Parallel.For to prevent sequential processing if persistence implementation isn't async.

### DIFF
--- a/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
@@ -52,6 +52,8 @@ abstract class LoopRunner : BaseRunner
 
             var cancellationToken = stopLoop.Token;
 
+            var po = new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount };
+
             while (!Shutdown)
             {
                 try
@@ -60,7 +62,7 @@ abstract class LoopRunner : BaseRunner
                     countdownEvent.Reset(BatchSize);
                     var batchDuration = Stopwatch.StartNew();
 
-                    await TaskHelper.ParallelFor(BatchSize, () => SendMessage(session)).ConfigureAwait(false);
+                    Parallel.For((long)0, BatchSize, po, i => { SendMessage(session).ConfigureAwait(false).GetAwaiter().GetResult(); });
 
                     count += BatchSize;
 


### PR DESCRIPTION
Resolves #98