### PR TITLE
Debug build now has Debug log output

### DIFF
--- a/src/PerformanceTests/NServiceBus5/App.Local.config
+++ b/src/PerformanceTests/NServiceBus5/App.Local.config
@@ -4,4 +4,9 @@
     <add xdt:Transform="SetAttributes" xdt:Locator="Match(key)" key="WarmupDuration" value="00:00:01" />
     <add xdt:Transform="SetAttributes" xdt:Locator="Match(key)" key="RunDuration" value="00:00:29" />
   </appSettings>
+  <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd">
+    <rules>
+      <logger xdt:Transform="SetAttributes" xdt:Locator="Match(name)" name="*" minlevel="Info" />
+    </rules>
+  </nlog>
 </configuration>

--- a/src/PerformanceTests/NServiceBus5/App.config
+++ b/src/PerformanceTests/NServiceBus5/App.config
@@ -17,7 +17,7 @@
     <rules>
         <logger name="NServiceBus.Azure.Transports.WindowsAzureServiceBus.AzureServiceBusQueueCreator" maxlevel="Info" final="true" />
         <logger name="NServiceBus.Distributor.MSMQ.*" maxlevel="Info" final="true" />
-        <logger name="*" minlevel="Info" writeTo="file,trace,console" />
+        <logger name="*" minlevel="Debug" writeTo="file,trace,console" />
     </rules>
   </nlog>
 

--- a/src/PerformanceTests/NServiceBus6/App.Local.config
+++ b/src/PerformanceTests/NServiceBus6/App.Local.config
@@ -4,4 +4,9 @@
     <add xdt:Transform="SetAttributes" xdt:Locator="Match(key)" key="WarmupDuration" value="00:00:01" />
     <add xdt:Transform="SetAttributes" xdt:Locator="Match(key)" key="RunDuration" value="00:00:29" />
   </appSettings>
+  <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd">
+    <rules>
+      <logger xdt:Transform="SetAttributes" xdt:Locator="Match(name)" name="*" minlevel="Info" />
+    </rules>
+  </nlog>
 </configuration>

--- a/src/PerformanceTests/NServiceBus6/App.config
+++ b/src/PerformanceTests/NServiceBus6/App.config
@@ -15,7 +15,7 @@
       <target name="console" xsi:type="ColoredConsole" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
     </targets>
     <rules>
-        <logger name="*" minlevel="Info" writeTo="file,trace,console" />
+        <logger name="*" minlevel="Debug" writeTo="file,trace,console" />
     </rules>
   </nlog>
 


### PR DESCRIPTION
Previously the debug build ran with Info log output. Debug builds are usually ran for resolving issues and debug output as default prevents the need to adjust the log level (developers are lazy...).