### PR TITLE
SagaInitiateRunner using guids

### DIFF
--- a/src/PerformanceTests/Common/Scenarios/SagaInitiate/SagaInitiateRunner.V5.cs
+++ b/src/PerformanceTests/Common/Scenarios/SagaInitiate/SagaInitiateRunner.V5.cs
@@ -1,26 +1,27 @@
 ﻿#if Version5
+using System;
 using NServiceBus.Saga;
 
 partial class SagaInitiateRunner
 {
-    public class TheSaga : Saga<SagaData>,
+    public class TheSaga : Saga<SagaCreateData>,
         IAmStartedByMessages<Command>
     {
-        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaCreateData> mapper)
         {
-            mapper.ConfigureMapping<Command>(m => m.Identifier).ToSaga(s => s.UniqueIdentifier);
+            mapper.ConfigureMapping<Command>(m => m.Identifier).ToSaga(s => s.Identifier);
         }
 
         public void Handle(Command message)
         {
-            Data.UniqueIdentifier = message.Identifier;
+            Data.Identifier = message.Identifier;
         }
     }
 
-    public class SagaData : ContainSagaData
+    public class SagaCreateData : ContainSagaData
     {
         [Unique]
-        public virtual int UniqueIdentifier { get; set; }
+        public virtual Guid Identifier { get; set; }
     }
 }
 #endif

--- a/src/PerformanceTests/Common/Scenarios/SagaInitiate/SagaInitiateRunner.V6.cs
+++ b/src/PerformanceTests/Common/Scenarios/SagaInitiate/SagaInitiateRunner.V6.cs
@@ -1,27 +1,28 @@
 ﻿#if Version6
+using System;
 using System.Threading.Tasks;
 using NServiceBus;
 
 partial class SagaInitiateRunner
 {
-    public class TheSaga : Saga<SagaData>,
+    public class TheSaga : Saga<SagaCreateData>,
         IAmStartedByMessages<Command>
     {
-        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaCreateData> mapper)
         {
-            mapper.ConfigureMapping<Command>(m => m.Identifier).ToSaga(s => s.UniqueIdentifier);
+            mapper.ConfigureMapping<Command>(m => m.Identifier).ToSaga(s => s.Identifier);
         }
 
         public Task Handle(Command message, IMessageHandlerContext context)
         {
-            Data.UniqueIdentifier = message.Identifier;
+            Data.Identifier = message.Identifier;
             return Task.FromResult(0);
         }
     }
 
-    public class SagaData : ContainSagaData
+    public class SagaCreateData : ContainSagaData
     {
-        public virtual int UniqueIdentifier { get; set; }
+        public virtual Guid Identifier { get; set; }
     }
 }
 #endif

--- a/src/PerformanceTests/Common/Scenarios/SagaInitiate/SagaInitiateRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SagaInitiate/SagaInitiateRunner.cs
@@ -1,24 +1,17 @@
-﻿using System.Threading;
+﻿using System;
 using System.Threading.Tasks;
 using Common.Scenarios;
 using NServiceBus;
 
 partial class SagaInitiateRunner : BaseRunner, ICreateSeedData
 {
-    int messageId;
-
     public Task SendMessage(ISession session)
     {
-        return session.SendLocal(new Command(Interlocked.Increment(ref messageId)));
+        return session.SendLocal(new Command { Identifier = Guid.NewGuid() });
     }
 
     public class Command : ICommand
     {
-        public Command(int id)
-        {
-            Identifier = id;
-        }
-
-        public int Identifier { get; set; }
+        public Guid Identifier { get; set; }
     }
 }


### PR DESCRIPTION
SagaInitiateRunner now using Guids to be more compatible with storages like Azure table storage that cannot easily cleanup data. Cleanup instructions on Azure are queued which needs polling and that results in unneeded delays.

Saga class also renamed to reference the intent and aligned the message property with the saga property name.