### PR TITLE
Tweaks

### DIFF
--- a/src/PerformanceTests/Tests/Categories/PersistersFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/PersistersFixture.cs
@@ -26,6 +26,7 @@ namespace Categories
             return PermutationGenerator.Generate(new Permutations
             {
                 Transports = new[] { Transport.MSMQ },
+                TransactionMode = new[] { TransactionMode.None, },
                 Persisters = (Persistence[])Enum.GetValues(typeof(Persistence)),
                 Serializers = new[] { Serialization.Json, },
                 OutboxModes = new[] { Outbox.Off, },

--- a/src/PerformanceTests/Tests/Categories/SendThroughputFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/SendThroughputFixture.cs
@@ -6,7 +6,7 @@ using Variables;
 
 namespace Categories
 { 
-    [TestFixture(Description = "Send throughput", Category = "Performance")]
+    [TestFixture(Description = "Send throughput", Category = "Performance"), Explicit]
     public class SendThroughputFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Tests/Categories/SerializerFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/SerializerFixture.cs
@@ -6,7 +6,7 @@ using Variables;
 namespace Categories
 {
 
-    [TestFixture(Description = "Serializer differences", Category = "Performance")]
+    [TestFixture(Description = "Serializer differences", Category = "Performance"), Explicit]
     public class SerializerFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]

--- a/src/PerformanceTests/Utils/Permutations/Permutations.cs
+++ b/src/PerformanceTests/Utils/Permutations/Permutations.cs
@@ -15,7 +15,7 @@ namespace Tests.Permutations
         public Transport[] Transports = (Transport[])Enum.GetValues(typeof(Transport));
         public GarbageCollector[] GarbageCollectors = { GarbageCollector.Server };
         public TransactionMode[] TransactionMode = { Variables.TransactionMode.Transactional };
-        public ConcurrencyLevel[] ConcurrencyLevels = { ConcurrencyLevel.EnvCores4x, };
+        public ConcurrencyLevel[] ConcurrencyLevels = { ConcurrencyLevel.EnvCores64x };
         public ScaleOut[] ScaleOuts = { ScaleOut.NoScaleOut };
     }
 }


### PR DESCRIPTION
- #207 : Concurrency increased from 4x to 64x the number of logical cores this should benefit the Azure VM environment which uses remoting for most storage.
- Persistence not using DTC/transport transactions to measure persistence performance without transport overhead.