### PR TITLE
Removed killing of test process if running too long

### DIFF
--- a/src/PerformanceTests/Tests/Categories/Base.cs
+++ b/src/PerformanceTests/Tests/Categories/Base.cs
@@ -109,12 +109,7 @@ namespace Categories
 
             using (var p = Process.Start(pi))
             {
-                var maxDurationInSeconds = 150;
-                if (!p.WaitForExit(maxDurationInSeconds * 1000))
-                {
-                    p.Kill();
-                    Assert.Fail($"Killed process because execution took more then {maxDurationInSeconds} seconds.");
-                }
+                p.WaitForExit();
                 if (p.ExitCode == (int)ReturnCodes.NotSupported)
                 {
                     Assert.Inconclusive("Not supported");


### PR DESCRIPTION
Removed killing of process as this is causing issues on the build server. Tests ran after this test result in a System.IO.IOException

```
System.IO.IOException : The process cannot access the file 'C:\BuildAgent\work\fa5f215bc71fc336\perftests\@\Performance\PersistersPublishTransactionModesFixture\PublishOneOnOneRunner\V5~Azure~Transactional~\Newtonsoft.Json.dll' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize)
   at System.IO.File.OpenFile(String path, FileAccess access, SafeFileHandle& handle)
   at System.IO.File.SetLastWriteTimeUtc(String path, DateTime lastWriteTimeUtc)
   at Tests.Tools.TestEnvironment.CopyAssembliesToStarupDir(DirectoryInfo destination, String[] baseFiles, FileInfo[] overrides) in C:\BuildAgent\work\b8379f157f55efb1\src\PerformanceTests\Tests\Tools\TestEnvironment.cs:line 81
   at Tests.Tools.TestEnvironment.CreateTestEnvironments(Permutation permutation) in C:\BuildAgent\work\b8379f157f55efb1\src\PerformanceTests\Tests\Tools\TestEnvironment.cs:line 47
   at Categories.Base.Tasks(Permutation permutation, String memberName) in C:\BuildAgent\work\b8379f157f55efb1\src\PerformanceTests\Tests\Categories\Base.cs:line 78
   at Categories.PersistersPublishTransactionModesFixture.PublishOneOnOneRunner(Permutation permutation) in C:\BuildAgent\work\b8379f157f55efb1\src\PerformanceTests\Tests\Categories\PersistersPublishTransactionModesFixture.cs:line 15
```

Reference

- https://builds.particular.net/viewLog.html?buildId=188670&tab=buildResultsDiv&buildTypeId=PerfTests_DeployAndRun