### PR TITLE
Made cloning of folders more resilient 

### DIFF
--- a/src/PerformanceTests/Tests/Categories/Base.cs
+++ b/src/PerformanceTests/Tests/Categories/Base.cs
@@ -109,7 +109,12 @@ namespace Categories
 
             using (var p = Process.Start(pi))
             {
-                p.WaitForExit();
+                var maxDurationInSeconds = 150;
+                if (!p.WaitForExit(maxDurationInSeconds * 1000))
+                {
+                    p.Kill();
+                    Assert.Fail($"Killed process because execution took more then {maxDurationInSeconds} seconds.");
+                }
                 if (p.ExitCode == (int)ReturnCodes.NotSupported)
                 {
                     Assert.Inconclusive("Not supported");

--- a/src/PerformanceTests/Tests/Categories/Base.cs
+++ b/src/PerformanceTests/Tests/Categories/Base.cs
@@ -16,6 +16,7 @@ namespace Categories
     {
         public static string SessionId;
         static readonly bool InvokeEnabled = bool.Parse(ConfigurationManager.AppSettings["InvokeEnabled"]);
+        static readonly TimeSpan MaxDuration = TimeSpan.Parse(ConfigurationManager.AppSettings["MaxDuration"]);
 
         public virtual void ReceiveRunner(Permutation permutation)
         {
@@ -109,11 +110,10 @@ namespace Categories
 
             using (var p = Process.Start(pi))
             {
-                var maxDurationInSeconds = 150;
-                if (!p.WaitForExit(maxDurationInSeconds * 1000))
+                if (!p.WaitForExit((int)MaxDuration.TotalMilliseconds))
                 {
                     p.Kill();
-                    Assert.Fail($"Killed process because execution took more then {maxDurationInSeconds} seconds.");
+                    Assert.Fail($"Killed process because execution took more then {MaxDuration}.");
                 }
                 if (p.ExitCode == (int)ReturnCodes.NotSupported)
                 {

--- a/src/PerformanceTests/Tests/app.config
+++ b/src/PerformanceTests/Tests/app.config
@@ -45,5 +45,6 @@
   </startup>
   <appSettings>
     <add key="InvokeEnabled" value="True" />
+    <add key="MaxDuration" value="00:10:00"/>
   </appSettings>
 </configuration>


### PR DESCRIPTION
- Reverted the killing of the process as that cause files to be locked for access but cloning is now resilient to such temporary issues.
- Duration after which to kill the process is increased to 10 minutes as 150 seconds was too short. Some seed/receive tests required more time due to 'slow' receives.

This resolves the issue on the build server where tests crashed with:

> System.IO.IOException : The process cannot access the file 'C:\BuildAgent\work\fa5f215bc71fc336\perftests\@\Performance\SagasFixture\SagaInitiateRunner\V6~RavenDB~Atomic~Sequential~\Newtonsoft.Json.dll' because it is being used by another process.