### PR TITLE
Critical error handling

### DIFF
--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -212,11 +212,11 @@ public abstract class BaseRunner : IConfigurationSource, IContext
         try
         {
             Log.Fatal("OnCriticalError", exception);
-            NLog.LogManager.Shutdown();
             Session.Close();
         }
         finally
         {
+            NLog.LogManager.Shutdown();
             Environment.FailFast("NServiceBus critical error", exception);
         }
     }
@@ -277,11 +277,11 @@ public abstract class BaseRunner : IConfigurationSource, IContext
         try
         {
             Log.Fatal("OnCriticalError", context.Exception);
-            NLog.LogManager.Shutdown();
             await context.Stop();
         }
         finally
         {
+            NLog.LogManager.Shutdown();
             Environment.FailFast("NServiceBus critical error", context.Exception);
         }
     }

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -211,12 +211,18 @@ public abstract class BaseRunner : IConfigurationSource, IContext
     {
         try
         {
-            Log.Fatal("OnCriticalError", exception);
-            Session.Close();
+            try
+            {
+                Log.Fatal("OnCriticalError", exception);
+                Session.Close();
+            }
+            finally
+            {
+                NLog.LogManager.Shutdown();
+            }
         }
         finally
         {
-            NLog.LogManager.Shutdown();
             Environment.FailFast("NServiceBus critical error", exception);
         }
     }
@@ -276,12 +282,18 @@ public abstract class BaseRunner : IConfigurationSource, IContext
     {
         try
         {
-            Log.Fatal("OnCriticalError", context.Exception);
-            await context.Stop();
+            try
+            {
+                Log.Fatal("OnCriticalError", context.Exception);
+                await context.Stop();
+            }
+            finally
+            {
+                NLog.LogManager.Shutdown();
+            }
         }
         finally
         {
-            NLog.LogManager.Shutdown();
             Environment.FailFast("NServiceBus critical error", context.Exception);
         }
     }


### PR DESCRIPTION
Critical errors are now logged, logging is flushed and it is attempted to stop the bus but on any condition will kill the process.