### PR TITLE
Purge and drain

### DIFF
--- a/src/PerformanceTests/Common/Common.Data.projitems
+++ b/src/PerformanceTests/Common/Common.Data.projitems
@@ -12,6 +12,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)AuditProfile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CheckGCServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CheckPlatform.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Shortcut\ShortcutBehavior.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Shortcut\ShortcutFeature.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IConfigureUnicastBus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EnvironmentStats.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IContext.cs" />

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -94,7 +94,7 @@ public abstract class BaseRunner : IConfigurationSource, IContext
 
     protected virtual Task Stop()
     {
-        return DrainMessages();
+        return Task.FromResult(0);
     }
 
     async Task CreateSeedData(ICreateSeedData instance)

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -42,7 +42,7 @@ public abstract class BaseRunner : IConfigurationSource, IContext
         InitData();
         MaxConcurrencyLevel = ConcurrencyLevelConverter.Convert(Permutation.ConcurrencyLevel);
 
-        await CreateOrPurgeQueues().ConfigureAwait(false); // Workaround for pubsub to self with purge on startup
+        await CreateOrPurgeAndDrainQueues().ConfigureAwait(false); // Workaround for pubsub to self with purge on startup
 
         var seedCreator = this as ICreateSeedData;
         if (seedCreator != null)
@@ -100,7 +100,7 @@ public abstract class BaseRunner : IConfigurationSource, IContext
     async Task CreateSeedData(ICreateSeedData instance)
     {
         Log.Info("Creating or purging queues...");
-        await CreateOrPurgeQueues().ConfigureAwait(false);
+        await CreateOrPurgeAndDrainQueues().ConfigureAwait(false);
         Log.Info("Creating send only endpoint...");
         await CreateSendOnlyEndpoint().ConfigureAwait(false);
 
@@ -147,12 +147,13 @@ public abstract class BaseRunner : IConfigurationSource, IContext
     }
 
 #if Version5
-    Task CreateOrPurgeQueues()
+    async Task CreateOrPurgeAndDrainQueues()
     {
         var configuration = CreateConfiguration();
         if (IsPurgingSupported) configuration.PurgeOnStartup(true);
         var instance = Bus.Create(configuration).Start();
-        return new Session(instance).CloseWithSuppress();
+        await DrainMessages().ConfigureAwait(false);
+        await new Session(instance).CloseWithSuppress().ConfigureAwait(false);
     }
 
     Task CreateSendOnlyEndpoint()
@@ -232,11 +233,12 @@ public abstract class BaseRunner : IConfigurationSource, IContext
     }
 
 #else
-    async Task CreateOrPurgeQueues()
+    async Task CreateOrPurgeAndDrainQueues()
     {
         var configuration = CreateConfiguration();
         if (IsPurgingSupported) configuration.PurgeOnStartup(true);
         var instance = await Endpoint.Start(configuration).ConfigureAwait(false);
+        await DrainMessages().ConfigureAwait(false);
         await new Session(instance).CloseWithSuppress().ConfigureAwait(false);
     }
 
@@ -251,7 +253,6 @@ public abstract class BaseRunner : IConfigurationSource, IContext
     async Task CreateEndpoint()
     {
         var configuration = CreateConfiguration();
-        configuration.EnableFeature<NServiceBus.Performance.SimpleStatisticsFeature>();
         configuration.CustomConfigurationSource(this);
 
         if (SendOnly)
@@ -352,20 +353,30 @@ public abstract class BaseRunner : IConfigurationSource, IContext
         while (condition()) yield return i++;
     }
 
-    protected async Task DrainMessages()
+    async Task DrainMessages()
     {
-        var startCount = Statistics.Instance.NumberOfMessages;
-        long current;
-
-        Log.Info("Draining queue...");
-        do
+        try
         {
-            current = Statistics.Instance.NumberOfMessages;
-            Log.Debug("Delaying to detect receive activity...");
-            await Task.Delay(1000).ConfigureAwait(false);
-        } while (Statistics.Instance.NumberOfMessages > current);
+            const int DrainPollInterval = 1500;
+            var startCount = ShortcutBehavior.Count;
+            long current;
+            var start = Stopwatch.StartNew();
+            ShortcutBehavior.Shortcut = true;
 
-        var diff = current - startCount;
-        Log.InfoFormat("Drained {0} message(s)", diff);
+            Log.Info("Draining queue...");
+            do
+            {
+                current = ShortcutBehavior.Count;
+                Log.DebugFormat("Delaying to detect receive activity, last count is {0}...", current);
+                await Task.Delay(DrainPollInterval).ConfigureAwait(false);
+            } while (ShortcutBehavior.Count > current);
+
+            var diff = current - startCount;
+            Log.InfoFormat("Drained {0:N0} message(s) in {1:N0}ms", diff, start.ElapsedMilliseconds);
+        }
+        finally
+        {
+            ShortcutBehavior.Shortcut = false;
+        }
     }
 }

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -75,11 +75,11 @@ public abstract class BaseRunner : IConfigurationSource, IContext
             Statistics.Instance.Reset(GetType().Name);
             await Task.Delay(runDuration).ConfigureAwait(false);
 
+            Statistics.Instance.Dump();
             Shutdown = true;
             Log.Info("Stopping...");
             await Stop().ConfigureAwait(false);
             Log.Info("Stopped");
-            Statistics.Instance.Dump();
         }
         finally
         {

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -167,7 +167,6 @@ public abstract class BaseRunner : IConfigurationSource, IContext
     Task CreateEndpoint()
     {
         var configuration = CreateConfiguration();
-        configuration.EnableFeature<NServiceBus.Performance.SimpleStatisticsFeature>();
         configuration.CustomConfigurationSource(this);
         configuration.DefineCriticalErrorAction(OnCriticalError);
 

--- a/src/PerformanceTests/Common/Shortcut/ShortcutBehavior.cs
+++ b/src/PerformanceTests/Common/Shortcut/ShortcutBehavior.cs
@@ -1,0 +1,54 @@
+#if Version6
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus.Pipeline;
+
+public class ShortcutBehavior : Behavior<ITransportReceiveContext>
+{
+    public static bool Shortcut;
+    public static long Count;
+
+    public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
+    {
+        if (Shortcut)
+        {
+            Interlocked.Increment(ref Count);
+            return Task.FromResult(0);
+        }
+        return next();
+    }
+}
+
+#else
+
+using System;
+using System.Threading;
+using NServiceBus.Pipeline;
+using NServiceBus.Pipeline.Contexts;
+
+public class ShortcutBehavior : IBehavior<IncomingContext>
+{
+    public static bool Shortcut;
+    public static long Count;
+
+    public void Invoke(IncomingContext context, Action next)
+    {
+        if (Shortcut)
+        {
+            Interlocked.Increment(ref Count);
+            return;
+        }
+        next();
+    }
+
+    public class Step : RegisterStep
+    {
+        public Step() : base(typeof(Step).FullName, typeof(ShortcutBehavior), "Shortcuts pipeline.")
+        {
+            InsertBefore(WellKnownStep.CreateChildContainer);
+        }
+    }
+}
+
+#endif

--- a/src/PerformanceTests/Common/Shortcut/ShortcutFeature.cs
+++ b/src/PerformanceTests/Common/Shortcut/ShortcutFeature.cs
@@ -1,0 +1,16 @@
+using NServiceBus;
+using NServiceBus.Features;
+
+public class ShortcutFeature : Feature
+{
+    public ShortcutFeature()
+    {
+        EnableByDefault();
+    }
+
+    protected override void Setup(FeatureConfigurationContext context)
+    {
+        context.Container.ConfigureComponent<ShortcutBehavior>(DependencyLifecycle.SingleInstance);
+        context.Pipeline.Register(nameof(ShortcutBehavior), typeof(ShortcutBehavior), "Shortcut processing to drain queue ASAP transport agnostic.");
+    }
+}

--- a/src/PerformanceTests/Common/Statistics/SimpleStatisticsFeature.V5.cs
+++ b/src/PerformanceTests/Common/Statistics/SimpleStatisticsFeature.V5.cs
@@ -4,7 +4,6 @@ using System.Configuration;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
-using System.Linq;
 
 namespace NServiceBus.Performance
 {
@@ -15,13 +14,13 @@ namespace NServiceBus.Performance
     {
         static readonly string SettingKey = "NServiceBus/SimpleStatistics";
 
+        public SimpleStatisticsFeature()
+        {
+            EnableByDefault();
+        }
+
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var settings = ConfigurationManager.AppSettings;
-            bool enable;
-            if (settings.AllKeys.Contains(SettingKey) && bool.TryParse(settings[SettingKey], out enable) && !enable) return;
-
-            EnableByDefault();
             context.Container.ConfigureComponent<Collector>(DependencyLifecycle.SingleInstance);
             RegisterStartupTask<StartupTask>();
 

--- a/src/PerformanceTests/Common/Statistics/SimpleStatisticsFeature.V6.cs
+++ b/src/PerformanceTests/Common/Statistics/SimpleStatisticsFeature.V6.cs
@@ -7,7 +7,6 @@ using System.Threading;
 
 namespace NServiceBus.Performance
 {
-    using System.Linq;
     using System.Threading.Tasks;
     using Features;
     using Logging;
@@ -16,14 +15,13 @@ namespace NServiceBus.Performance
     {
         private static readonly string SettingKey = "NServiceBus/SimpleStatistics";
 
+        public SimpleStatisticsFeature()
+        {
+            EnableByDefault();
+        }
+
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var settings = ConfigurationManager.AppSettings;
-            bool enable;
-
-            if (settings.AllKeys.Contains(SettingKey) && bool.TryParse(settings[SettingKey], out enable) && !enable) return;
-
-            EnableByDefault();
             var task = new StartupTask
             {
                 Collector = new Collector()

--- a/src/PerformanceTests/Persistence.V6.RavenDB.V4/RavenDBProfile.cs
+++ b/src/PerformanceTests/Persistence.V6.RavenDB.V4/RavenDBProfile.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;


### PR DESCRIPTION
Performance tests perform a purge operation first. Not all transports support purge on startup or the purge operation is async. This makes sure that the queue is drained first.