### PR TITLE
WIP: Improvements

### DIFF
--- a/src/PerformanceTests/ArtifactsParser/Program.cs
+++ b/src/PerformanceTests/ArtifactsParser/Program.cs
@@ -2,6 +2,7 @@
 
 namespace ArtifactsParser
 {
+    using System.Diagnostics;
     using System.IO;
 
     class Program
@@ -14,10 +15,15 @@ namespace ArtifactsParser
                 return;
             }
             var path = args[0];
+            var src = Path.GetFullPath(path);
+            Console.WriteLine("{0} => {1}", path, src);
+
             var csv = ScanLogs.ToCsvString(path);
-            var dst = Path.Combine(path, "report.csv");
+            var dst = Path.Combine(src, $"report-{DateTime.Now:yyyy-MM-dd_hhmmss}.csv");
             File.WriteAllText(dst, csv);
-            Console.WriteLine("Parsed '{0}' recursively and written to '{1}'", path, dst);
+            Console.WriteLine("Parsed '{0}' recursively and written to '{1}'", src, dst);
+
+            Process.Start(dst);
         }
     }
 }

--- a/src/PerformanceTests/Common/Program.cs
+++ b/src/PerformanceTests/Common/Program.cs
@@ -113,6 +113,19 @@ namespace Host
             log.InfoFormat("Fixture: {0}", permutation.Fixture);
             log.InfoFormat("Code: {0}", permutation.Code);
             log.InfoFormat("Id: {0}", permutation.Id);
+
+            log.InfoFormat("AuditMode: {0}", permutation.AuditMode);
+            log.InfoFormat("MessageSize: {0}", permutation.MessageSize);
+            log.InfoFormat("Version: {0}", permutation.Version);
+            log.InfoFormat("Outbox: {0}", permutation.OutboxMode);
+            log.InfoFormat("Persistence: {0}", permutation.Persister);
+            log.InfoFormat("Platform: {0}", permutation.Platform);
+            log.InfoFormat("Serializer: {0}", permutation.Serializer);
+            log.InfoFormat("Transport: {0}", permutation.Transport);
+            log.InfoFormat("GC: {0}", permutation.GarbageCollector);
+            log.InfoFormat("TransactionMode: {0}", permutation.TransactionMode);
+            log.InfoFormat("ConcurrencyLevel: {0}", permutation.ConcurrencyLevel);
+            log.InfoFormat("ScaleOut: {0}", permutation.ScaleOut);
         }
 
         static void ValidateServicePointManager(Permutation permutation)

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -121,19 +121,19 @@ public abstract class BaseRunner : IConfigurationSource, IContext
             var interval = TimeSpan.FromSeconds(1.5);
             var current = NServiceBus.Performance.StatisticsBehavior.ShortcutCount;
             var stopTimestamp = DateTime.UtcNow.Add(runDuration);
-            bool expired, activity;
-            var remaining = stopTimestamp - DateTime.UtcNow;
+            bool isExpired, hasIncomingMessages;
+            var remainingTime = stopTimestamp - DateTime.UtcNow;
             do
             {
-                Log.InfoFormat("Waiting until run duration expires in {0,5:N1}s or all messages received ({1,7:N0} of {2,7:N0} / {3,4:N1}%)", remaining.TotalSeconds, current, seedCount, current * 100.0 / seedCount);
-                await Task.Delay(remaining > interval ? interval : remaining).ConfigureAwait(false);
-                remaining = stopTimestamp - DateTime.UtcNow;
+                Log.InfoFormat("Waiting until run duration expires in {0,5:N1}s or all messages received ({1,7:N0} of {2,7:N0} / {3,4:N1}%)", remainingTime.TotalSeconds, current, seedCount, current * 100.0 / seedCount);
+                await Task.Delay(remainingTime > interval ? interval : remainingTime).ConfigureAwait(false);
+                remainingTime = stopTimestamp - DateTime.UtcNow;
                 current = NServiceBus.Performance.StatisticsBehavior.ShortcutCount;
-                activity = seedCount > current;
-                expired = remaining.Ticks < 0;
-            } while (activity && !expired);
-            if (!activity) Log.Info("No more incoming messages.");
-            if (expired) Log.Info("Maximum run duration expired.");
+                hasIncomingMessages = seedCount > current;
+                isExpired = remainingTime.Ticks < 0;
+            } while (hasIncomingMessages && !isExpired);
+            if (!hasIncomingMessages) Log.Info("No more incoming messages.");
+            if (isExpired) Log.Info("Maximum run duration expired.");
 
             Statistics.Instance.Dump();
             WritePermutationSeedDurationFactor();

--- a/src/PerformanceTests/Common/Scenarios/PerpetualRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/PerpetualRunner.cs
@@ -21,7 +21,7 @@ abstract class PerpetualRunner : BaseRunner
         {
             if (start.ElapsedMilliseconds > duration)
             {
-                Log.Warn("Seed window ({0:N0}ms) expired!");
+                Log.WarnFormat("Seed window ({0:N0}ms) expired!", duration);
                 break;
             }
             var remaining = seedSize - count;

--- a/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V5.cs
+++ b/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V5.cs
@@ -1,5 +1,6 @@
 #if Version5
 using System;
+using System.Threading;
 using NServiceBus.Pipeline;
 using NServiceBus.Pipeline.Contexts;
 
@@ -7,6 +8,8 @@ namespace NServiceBus.Performance
 {
     public class StatisticsBehavior : IBehavior<IncomingContext>
     {
+        internal static bool Shortcut = false;
+        internal static long ShortcutCount;
         readonly Implementation provider;
         public StatisticsBehavior(Implementation provider)
         {
@@ -15,6 +18,11 @@ namespace NServiceBus.Performance
 
         public void Invoke(IncomingContext context, Action next)
         {
+            if (Shortcut)
+            {
+                Interlocked.Increment(ref ShortcutCount);
+                return;
+            }
             var start = provider.Timestamp();
             try
             {

--- a/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V5.cs
+++ b/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V5.cs
@@ -11,6 +11,7 @@ namespace NServiceBus.Performance
         internal static bool Shortcut = false;
         internal static long ShortcutCount;
         readonly Implementation provider;
+
         public StatisticsBehavior(Implementation provider)
         {
             this.provider = provider;
@@ -18,9 +19,9 @@ namespace NServiceBus.Performance
 
         public void Invoke(IncomingContext context, Action next)
         {
+            Interlocked.Increment(ref ShortcutCount);
             if (Shortcut)
             {
-                Interlocked.Increment(ref ShortcutCount);
                 return;
             }
             var start = provider.Timestamp();

--- a/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V6.cs
+++ b/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V6.cs
@@ -11,16 +11,17 @@ namespace NServiceBus.Performance
         internal static bool Shortcut = false;
         internal static long ShortcutCount;
         private readonly Implementation provider;
-        public StatisticsBehavior(Implementation provider)
+
+public StatisticsBehavior(Implementation provider)
         {
             this.provider = provider;
         }
 
         public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
         {
+            Interlocked.Increment(ref ShortcutCount);
             if (Shortcut)
             {
-                Interlocked.Increment(ref ShortcutCount);
                 return;
             }
             var start = provider.Timestamp();

--- a/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V6.cs
+++ b/src/PerformanceTests/Common/Statistics/StatisticsBehavior.V6.cs
@@ -1,13 +1,15 @@
 #if Version6
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using NServiceBus.Pipeline;
 
 namespace NServiceBus.Performance
 {
-    using System.Threading.Tasks;
-
     public class StatisticsBehavior : Behavior<ITransportReceiveContext>
     {
+        internal static bool Shortcut = false;
+        internal static long ShortcutCount;
         private readonly Implementation provider;
         public StatisticsBehavior(Implementation provider)
         {
@@ -16,6 +18,11 @@ namespace NServiceBus.Performance
 
         public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
         {
+            if (Shortcut)
+            {
+                Interlocked.Increment(ref ShortcutCount);
+                return;
+            }
             var start = provider.Timestamp();
             try
             {

--- a/src/PerformanceTests/NServiceBus5/App.config
+++ b/src/PerformanceTests/NServiceBus5/App.config
@@ -22,7 +22,7 @@
   </nlog>
 
   <appSettings>
-    <add key="SeedDurationFactor" value="0.60" />
+    <add key="SeedDurationFactor" value="0.45" />
     <add key="WarmupDuration" value="00:00:00.500" />
     <add key="RunDuration" value="00:00:15" />
     <add key="NServiceBus/Persistence/NHibernate/dialect" value="NHibernate.Dialect.MsSql2012Dialect" />

--- a/src/PerformanceTests/NServiceBus5/App.config
+++ b/src/PerformanceTests/NServiceBus5/App.config
@@ -12,7 +12,7 @@
     <targets>
       <target name="file" xsi:type="File" fileName="trace.log" layout="${longdate:universalTime=true}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
       <target name="trace" xsi:type="OutputDebugString" layout="${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
-      <target name="console" xsi:type="ColoredConsole" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${exception:format=message}}" />
+      <target name="console" xsi:type="ColoredConsole" layout="${longdate}|${level:uppercase=true}|${threadid:padding=5}|${logger}|${message}${onexception:${exception:format=message}}" />
     </targets>
     <rules>
         <logger name="NServiceBus.Azure.Transports.WindowsAzureServiceBus.AzureServiceBusQueueCreator" maxlevel="Info" final="true" />

--- a/src/PerformanceTests/NServiceBus6/App.config
+++ b/src/PerformanceTests/NServiceBus6/App.config
@@ -20,7 +20,7 @@
   </nlog>
 
   <appSettings>
-    <add key="SeedDurationFactor" value="0.60" />
+    <add key="SeedDurationFactor" value="0.45" />
     <add key="SenderSide" value="localhost" />
     <add key="WarmupDuration" value="00:00:00.500" />
     <add key="RunDuration" value="00:00:15" />

--- a/src/PerformanceTests/NServiceBus6/App.config
+++ b/src/PerformanceTests/NServiceBus6/App.config
@@ -12,7 +12,7 @@
     <targets>
       <target name="file" xsi:type="File" fileName="trace.log" layout="${longdate:universalTime=true}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
       <target name="trace" xsi:type="OutputDebugString" layout="${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}" />
-      <target name="console" xsi:type="ColoredConsole" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger}|${message}${onexception:${exception:format=message}}" />
+      <target name="console" xsi:type="ColoredConsole" layout="${longdate}|${level:uppercase=true}|${threadid:padding=2}|${logger}|${message}${onexception:${exception:format=message}}" />
     </targets>
     <rules>
         <logger name="*" minlevel="Debug" writeTo="file,trace,console" />

--- a/src/PerformanceTests/Tests/Categories/ConcurrencyFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/ConcurrencyFixture.cs
@@ -22,9 +22,9 @@ namespace Categories
                 Transports = (Transport[])Enum.GetValues(typeof(Transport)),
                 Serializers = new[] { Serialization.Json, },
                 OutboxModes = new[] { Outbox.Off, },
-                TransactionMode = new[] { TransactionMode.Receive, },
+                TransactionMode = (TransactionMode[])Enum.GetValues(typeof(TransactionMode)),
                 ConcurrencyLevels = (ConcurrencyLevel[])Enum.GetValues(typeof(ConcurrencyLevel)),
-            });
+            }, p => p.TransactionMode != TransactionMode.Default);
         }
     }
 }

--- a/src/PerformanceTests/Tests/Categories/SerializerFixture.cs
+++ b/src/PerformanceTests/Tests/Categories/SerializerFixture.cs
@@ -6,7 +6,7 @@ using Variables;
 namespace Categories
 {
 
-    [TestFixture(Description = "Serializer differences", Category = "Performance"), Explicit]
+    [TestFixture(Description = "Serializer differences", Category = "Performance")]
     public class SerializerFixture : Base
     {
         [TestCaseSource(nameof(CreatePermutations))]
@@ -20,9 +20,10 @@ namespace Categories
             return PermutationGenerator.Generate(new Permutations
             {
                 Transports = new[] { Transport.MSMQ },
-                Serializers = new[] { Serialization.Json, Serialization.Xml  },
-                MessageSizes = new [] {MessageSize.Tiny },
+                Serializers = new[] { Serialization.Json, Serialization.Xml },
+                MessageSizes = new[] { MessageSize.Tiny },
                 OutboxModes = new[] { Outbox.Off, },
+                TransactionMode = new[] { TransactionMode.None, }
             });
         }
     }

--- a/src/PerformanceTests/Transport.V6.AzureServiceBus.V7/AzureServiceBusProfile.cs
+++ b/src/PerformanceTests/Transport.V6.AzureServiceBus.V7/AzureServiceBusProfile.cs
@@ -24,6 +24,10 @@ class AzureServiceBusProfile : IProfile, INeedPermutation
             .Sanitization().UseStrategy<ValidateAndHashIfNeeded>()
             ;
 
+        transport.MessagingFactories().BatchFlushInterval(TimeSpan.FromMilliseconds(50));
+        transport.MessagingFactories().NumberOfMessagingFactoriesPerNamespace(Math.Max(5, concurrencyLevel / 32));
+        transport.Queues().EnablePartitioning(true);
+
         if (Permutation.TransactionMode != TransactionMode.Default
             && Permutation.TransactionMode != TransactionMode.None
             && Permutation.TransactionMode != TransactionMode.Receive
@@ -31,5 +35,7 @@ class AzureServiceBusProfile : IProfile, INeedPermutation
             ) throw new NotSupportedException("TransactionMode: " + Permutation.TransactionMode);
 
         if (Permutation.TransactionMode != TransactionMode.Default) transport.Transactions(Permutation.GetTransactionMode());
+
+
     }
 }

--- a/src/PerformanceTests/Utils/ScanLogs.cs
+++ b/src/PerformanceTests/Utils/ScanLogs.cs
@@ -64,6 +64,7 @@ public class ScanLogs
 
     const string Delimiter = "\t";
     static bool Align = false;
+    static readonly string NA = string.Empty;
 
 
     public static string ToCsvString(string path)
@@ -77,7 +78,7 @@ public class ScanLogs
         foreach (var k in keys)
         {
             var l = items
-                .Select(x => x.ContainsKey(k) ? x[k] : "NA")
+                .Select(x => x.ContainsKey(k) ? x[k] : NA)
                 .Max(x => x.Length);
 
             l = Math.Max(l, k.Length);
@@ -91,12 +92,12 @@ public class ScanLogs
             foreach (var k in keys)
             {
                 var l = items
-                    .Select(x => x.ContainsKey(k) ? x[k] : "NA")
+                    .Select(x => x.ContainsKey(k) ? x[k] : NA)
                     .Max(x => x.Length);
 
                 l = Math.Max(l, k.Length);
 
-                var v = i.ContainsKey(k) ? i[k] : "NA";
+                var v = i.ContainsKey(k) ? i[k] : NA;
 
                 if (Align)
                 {

--- a/src/PerformanceTests/Utils/Statistics.cs
+++ b/src/PerformanceTests/Utils/Statistics.cs
@@ -29,6 +29,7 @@ public class Statistics : IDisposable
 
     public long NumberOfMessages => numberOfMessages;
     public long NumberOfRetries => numberOfRetries;
+    public double Throughput { get; private set; }
 
 
     ~Statistics()
@@ -112,9 +113,9 @@ public class Statistics : IDisposable
         LogStats("ReceiveFirstLastDuration", durationSeconds, "s");
         LogStats("NumberOfMessages", NumberOfMessages, "#");
 
-        var throughput = NumberOfMessages / durationSeconds;
+        Throughput = NumberOfMessages / durationSeconds;
 
-        LogStats("Throughput", throughput, "msg/s");
+        LogStats("Throughput", Throughput, "msg/s");
 
         LogStats("NumberOfRetries", NumberOfRetries, "#");
 


### PR DESCRIPTION
CSV/TSB report generator 

- not overwriting existing report by using timestamp in filename
- NA values but just empty cells
- Logging now writing individual permutation property values to these show up as columns

Azure Service Bus transport

- Suppressing ObjectDisposedException failures to workaround V7 bug

Seeding

- Default seed/receive ratio lowered as seeding has become faster on all transports
- Formatting of seed window expired message
- Adaptive SeedDurationFactor using history of previous permutation runs to run a seed/receive test as close to the wanted test duration

Processing

- Detect if there are still incoming message to stop the test earlier instead of just waiting until the run duration is elapsed

Purging/draining

- CreateOrPurge now drains messages from the queue
- Message draining shortcuts the pipeline to drain ASAP

Utility

- Added TaskWhenAllThrottled for dev test purposes