### PR TITLE
Resolves bug related to draining messages at start

### DIFF
--- a/src/PerformanceTests/Common/Shortcut/ShortcutBehavior.cs
+++ b/src/PerformanceTests/Common/Shortcut/ShortcutBehavior.cs
@@ -29,7 +29,7 @@ using NServiceBus.Pipeline.Contexts;
 
 public class ShortcutBehavior : IBehavior<IncomingContext>
 {
-    public static bool Shortcut;
+    public static volatile bool Shortcut;
     public static long Count;
 
     public void Invoke(IncomingContext context, Action next)


### PR DESCRIPTION
Draining during purge operation didn't work properly as messages got processed before the draining could be started due to messages already being received and processed before the endpoint is completely initialized when calling `await Endpoint.Start(configuration)`