### PR TITLE
Fix v7 host by adding ConcurrencyProfile

### DIFF
--- a/src/PerformanceTests/NServiceBus7/ConcurrencyProfile.cs
+++ b/src/PerformanceTests/NServiceBus7/ConcurrencyProfile.cs
@@ -1,0 +1,12 @@
+using NServiceBus;
+using Tests.Permutations;
+
+class ConcurrencyProfile : IProfile, INeedPermutation
+{
+    public Permutation Permutation { private get; set; }
+
+    public void Configure(EndpointConfiguration cfg)
+    {
+        cfg.LimitMessageProcessingConcurrencyTo(ConcurrencyLevelConverter.Convert(Permutation.ConcurrencyLevel));
+    }
+}

--- a/src/PerformanceTests/NServiceBus7/NServiceBus7.csproj
+++ b/src/PerformanceTests/NServiceBus7/NServiceBus7.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConcurrencyProfile.cs" />
     <Compile Include="PermutationTransactionExtention.cs" />
     <Compile Include="Session.cs" />
   </ItemGroup>


### PR DESCRIPTION
@ramonsmits This is the reason for the major performance regression I noticed in the v7 test results. Looks like the max concurrency wasn't being set properly with the v7 host runner.