### PR TITLE
Seeding improvements

### DIFF
--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -127,8 +127,8 @@ public abstract partial class BaseRunner : IContext
                         }
                         catch (OperationCanceledException)
                         {
+                            Interlocked.Decrement(ref count);
                         }
-
                     }).ConfigureAwait(false);
                 Interlocked.Add(ref count, currentBatchSize);
                 var duration = sw.ElapsedMilliseconds;

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -111,7 +111,7 @@ public abstract partial class BaseRunner : IContext
             const int MinimumBatchSeedDuration = 2500;
             var batchSize = 512;
 
-            Log.InfoFormat("BatchHelper type: {0}", BatchHelper.Instance);
+            Log.InfoFormat("BatchHelper type: {0}", BatchHelper.Instance.GetType());
 
             while (!cts.Token.IsCancellationRequested)
             {

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -26,7 +26,6 @@ public abstract partial class BaseRunner : IContext
     protected int MaxConcurrencyLevel { private set; get; }
 
     protected static bool Shutdown { private set; get; }
-    protected readonly BatchHelper.IBatchHelper BatchHelper = global::BatchHelper.Instance;
     protected readonly Statistics Statistics = Statistics.Instance;
 
     public async Task Execute(Permutation permutation, string endpointName)
@@ -112,11 +111,13 @@ public abstract partial class BaseRunner : IContext
             const int MinimumBatchSeedDuration = 2500;
             var batchSize = 512;
 
+            Log.InfoFormat("BatchHelper type: {0}", BatchHelper.Instance);
+
             while (!cts.Token.IsCancellationRequested)
             {
                 var currentBatchSize = batchSize;
                 var sw = Stopwatch.StartNew();
-                await BatchHelper.Batch(currentBatchSize, i => instance.SendMessage(Session)).ConfigureAwait(false);
+                await BatchHelper.Instance.Batch(currentBatchSize, i => instance.SendMessage(Session)).ConfigureAwait(false);
                 Interlocked.Add(ref count, currentBatchSize);
                 var duration = sw.ElapsedMilliseconds;
                 if (duration < MinimumBatchSeedDuration)

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -244,8 +244,8 @@ public abstract partial class BaseRunner : IContext
                 lock (random) next = random.NextDouble();
                 next *= 0.2; // max 20% jitter
                 next += 1D;
-                next *= 100 * Math.Pow(2, ++attempts);
-                var delay = TimeSpan.FromMilliseconds(next);
+                next *= 100 * Math.Pow(2, attempts++);
+                var delay = TimeSpan.FromMilliseconds(next); // Results in 100ms, 200ms, 400ms, 800ms, etc. including max 20% random jitter.
                 Log.WarnFormat("{0} attempt {1} / {2} : {3} ({4})", id, attempts, delay, ex.Message, ex.GetType());
                     await Task.Delay(delay, token)
                         .ConfigureAwait(false);

--- a/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
@@ -51,6 +51,8 @@ abstract class LoopRunner : BaseRunner
 
             const int MinimumBatchSeedDuration = 2500;
 
+            Log.InfoFormat("BatchHelper type: {0}", BatchHelper.Instance);
+
             while (!stopLoopCancellationToken.IsCancellationRequested)
             {
                 try
@@ -59,7 +61,7 @@ abstract class LoopRunner : BaseRunner
                     countdownEvent.Reset(batchSize);
                     var batchDuration = Stopwatch.StartNew();
 
-                    await BatchHelper.Batch(batchSize, i => SendMessage(session)).ConfigureAwait(false);
+                    await BatchHelper.Instance.Batch(batchSize, i => SendMessage(session)).ConfigureAwait(false);
 
                     count += batchSize;
 

--- a/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
@@ -51,7 +51,7 @@ abstract class LoopRunner : BaseRunner
 
             const int MinimumBatchSeedDuration = 2500;
 
-            Log.InfoFormat("BatchHelper type: {0}", BatchHelper.Instance);
+            Log.InfoFormat("BatchHelper type: {0}", BatchHelper.Instance.GetType());
 
             while (!stopLoopCancellationToken.IsCancellationRequested)
             {

--- a/src/PerformanceTests/Common/Scenarios/PerpetualRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/PerpetualRunner.cs
@@ -15,7 +15,7 @@ public abstract class PerpetualRunner : BaseRunner
 
         Log.InfoFormat("Trying to seed {0:N0} items within {1:N0}ms...", seedSize, duration);
 
-        Log.InfoFormat("BatchHelper type: {0}", BatchHelper.Instance);
+        Log.InfoFormat("BatchHelper type: {0}", BatchHelper.Instance.GetType());
 
         var start = Stopwatch.StartNew();
         var chunkSize = 16;

--- a/src/PerformanceTests/Common/Scenarios/PerpetualRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/PerpetualRunner.cs
@@ -15,6 +15,8 @@ public abstract class PerpetualRunner : BaseRunner
 
         Log.InfoFormat("Trying to seed {0:N0} items within {1:N0}ms...", seedSize, duration);
 
+        Log.InfoFormat("BatchHelper type: {0}", BatchHelper.Instance);
+
         var start = Stopwatch.StartNew();
         var chunkSize = 16;
         var count = 0;
@@ -30,7 +32,7 @@ public abstract class PerpetualRunner : BaseRunner
 
             Log.InfoFormat("\tSeeding {0:N0} items...", j);
 
-            await BatchHelper.Batch(j, i => Seed(i + count /*no issue, as we await*/, session)).ConfigureAwait(false);
+            await BatchHelper.Instance.Batch(j, i => Seed(i + count /*no issue, as we await*/, session)).ConfigureAwait(false);
             chunkSize *= 2;
             count += j;
         } while (count < seedSize);

--- a/src/PerformanceTests/Common/Shortcut/ShortcutFeature.cs
+++ b/src/PerformanceTests/Common/Shortcut/ShortcutFeature.cs
@@ -11,6 +11,8 @@ public class ShortcutFeature : Feature
     protected override void Setup(FeatureConfigurationContext context)
     {
         context.Container.ConfigureComponent<ShortcutBehavior>(DependencyLifecycle.SingleInstance);
-        context.Pipeline.Register(nameof(ShortcutBehavior), typeof(ShortcutBehavior), "Shortcut processing to drain queue ASAP transport agnostic.");
+#if Version5
+        context.Pipeline.Register<ShortcutBehavior.Step>();
+#endif
     }
 }

--- a/src/PerformanceTests/Transport.V6.MSMQ.V6/MsmqProfile.cs
+++ b/src/PerformanceTests/Transport.V6.MSMQ.V6/MsmqProfile.cs
@@ -13,6 +13,8 @@ class MsmqProfile : IProfile, INeedPermutation
 
     public void Configure(EndpointConfiguration endpointConfiguration)
     {
+        BatchHelper.Instance = new BatchHelper.TaskWhenAllTaskRun();
+
         var transport = endpointConfiguration.UseTransport<MsmqTransport>();
         transport.ConnectionString(ConfigurationHelper.GetConnectionString("MSMQ"));
 

--- a/src/PerformanceTests/Transport.V7.MSMQ_v1/MsmqProfile.cs
+++ b/src/PerformanceTests/Transport.V7.MSMQ_v1/MsmqProfile.cs
@@ -13,6 +13,8 @@ class MsmqProfile : IProfile, INeedPermutation
 
     public void Configure(EndpointConfiguration endpointConfiguration)
     {
+        BatchHelper.Instance = new BatchHelper.TaskWhenAllTaskRun();
+
         var transport = endpointConfiguration.UseTransport<MsmqTransport>();
         transport.DisableDeadLetterQueueing();
 

--- a/src/PerformanceTests/Utils/BatchHelper.cs
+++ b/src/PerformanceTests/Utils/BatchHelper.cs
@@ -19,6 +19,19 @@ public class BatchHelper
             return Task.WhenAll(sends);
         }
     }
+    public class TaskWhenAllTaskRun : IBatchHelper
+    {
+        public Task Batch(int count, Func<int, Task> action)
+        {
+            var sends = new Task[count];
+            for (var i = 0; i < count; i++)
+            {
+                var i2 = i;
+                sends[i] = Task.Run(() => action(i2));
+            }
+            return Task.WhenAll(sends);
+        }
+    }
 
     public class ParallelFor : IBatchHelper
     {


### PR DESCRIPTION
Seeding improvements:

- Seeding wasn't purely async on v6 and v7. Now it is, except for MSMQ which overrules the batchhelper with an implementation that uses Task.`Run`.
- Draining was broken on v5 resulted in seeding to never happen.
- Sends during seeding previously resulted in the whole test to fail. Sends are expected to sometimes fail, for example due to throttling or reaching a connection limit. Sends during seeding now allow for some retries to happen including exponential backoff. This results in transports like AmazonSQS and SQL Server to be able to complete the seeding operation.