### PR TITLE
Remove mscoree COM reference

### DIFF
--- a/src/PerformanceTests/Utils/Utils.csproj
+++ b/src/PerformanceTests/Utils/Utils.csproj
@@ -21,16 +21,4 @@
     <PackageReference Include="NUnit" Version="3.*" />
   </ItemGroup>
 
-  <ItemGroup>
-    <COMReference Include="mscoree">
-      <Guid>{5477469E-83B1-11D2-8B49-00A0C9B7C9C4}</Guid>
-      <VersionMajor>2</VersionMajor>
-      <VersionMinor>4</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
It doesn't seem to cause any compilation issues to remove this import and some of the tests I used for smoke-testing the change also ran without issues.

Maybe @Particular/endtoend-maintainers know why this was added initially?