### PR TITLE
Target netstandard in Utils

### DIFF
--- a/src/PerformanceTests/Utils/AssemblyScanner.cs
+++ b/src/PerformanceTests/Utils/AssemblyScanner.cs
@@ -10,7 +10,7 @@ public static class AssemblyScanner
 {
     public static IEnumerable<Assembly> GetAssemblies()
     {
-        var l = LogManager.GetLogger(nameof(AssemblyScanner));
+        var l = LogManager.GetLogger(typeof(AssemblyScanner));
 
         foreach (var path in Directory.EnumerateFiles(Environment.CurrentDirectory, "*.dll"))
         {

--- a/src/PerformanceTests/Utils/ConfigurationHelper.cs
+++ b/src/PerformanceTests/Utils/ConfigurationHelper.cs
@@ -4,7 +4,7 @@ using log4net;
 
 public static class ConfigurationHelper
 {
-    static readonly ILog Log = LogManager.GetLogger(nameof(Configuration));
+    static readonly ILog Log = LogManager.GetLogger(typeof(Configuration));
 
     public static string GetConnectionString(string connectionStringName)
     {

--- a/src/PerformanceTests/Utils/SessionExtensions.cs
+++ b/src/PerformanceTests/Utils/SessionExtensions.cs
@@ -4,7 +4,7 @@ using log4net;
 
 public static class SessionExtensions
 {
-    static ILog Log = LogManager.GetLogger(nameof(SessionExtensions));
+    static ILog Log = LogManager.GetLogger(typeof(SessionExtensions));
 
     public static async Task CloseWithSuppress(this ISession instance)
     {

--- a/src/PerformanceTests/Utils/Statistics.cs
+++ b/src/PerformanceTests/Utils/Statistics.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using log4net;
 using Tests.Permutations;
@@ -22,7 +21,7 @@ public class Statistics : IDisposable
 
     Process process;
 
-    static ILog logger = LogManager.GetLogger("Statistics");
+    static ILog logger = LogManager.GetLogger(typeof(Statistics));
 
     public long NumberOfMessages => numberOfMessages;
     public long NumberOfRetries => numberOfRetries;

--- a/src/PerformanceTests/Utils/Utils.csproj
+++ b/src/PerformanceTests/Utils/Utils.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <RootNamespace>Utils</RootNamespace>
     <AssemblyName>Utils</AssemblyName>
     <OutputPath>..\bin\$(Configuration)\Utils\</OutputPath>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="System.Configuration" />
   </ItemGroup>
   
@@ -17,6 +17,12 @@
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NUnit" Version="3.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.*" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.*" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
GetLogger(string) is not supported by log4net on the netstandard API. Another approach would be to use `GetLogger(Assembly.GetCallingAssembly(), name)`, but I think the typeof approach should work fine as well.
