### PR TITLE
Target .net core 2.0 in v7 host

### DIFF
--- a/src/PerformanceTests/Common/PerformanceCounters.cs
+++ b/src/PerformanceTests/Common/PerformanceCounters.cs
@@ -1,3 +1,4 @@
+#if NET452
 #if Version6 || Version7
 using Configuration = NServiceBus.EndpointConfiguration;
 #else
@@ -24,3 +25,4 @@ class PerformanceCounters : IProfile, INeedContext
 #endif
     }
 }
+#endif

--- a/src/PerformanceTests/Common/Program.cs
+++ b/src/PerformanceTests/Common/Program.cs
@@ -4,6 +4,7 @@ namespace Host
     using System.Globalization;
     using System.Linq;
     using System.Net;
+    using System.Reflection;
     using System.Runtime;
     using System.Threading;
     using System.Threading.Tasks;
@@ -30,7 +31,7 @@ namespace Host
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
-            XmlConfigurator.Configure();
+            XmlConfigurator.Configure(log4net.LogManager.GetRepository(Assembly.GetExecutingAssembly()));
 
             return MainAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         }

--- a/src/PerformanceTests/NServiceBus7/NServiceBus7.csproj
+++ b/src/PerformanceTests/NServiceBus7/NServiceBus7.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>Host</RootNamespace>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
@@ -18,8 +18,15 @@
     <PackageReference Include="Microsoft.VisualStudio.SlowCheetah" Version="3.0.61" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Log4Net" Version="3.0.0-*" />
-    <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="2.0.0-alpha0024" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="2.0.0-alpha0024" />
   </ItemGroup>
 
   <ItemGroup>
@@ -51,7 +58,7 @@
     </None>
   </ItemGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
     <PostBuildEvent>
       copy "$(TargetPath)NServiceBus7.x64.exe" "$(TargetDir)NServiceBus7.x86.exe"
       copy "$(TargetPath)NServiceBus7.x64.exe.config" "$(TargetDir)NServiceBus7.x86.exe.config"


### PR DESCRIPTION
Targeting core directly as this project will create the executing assembly in the tests.

Additional (required) changes:
* Conditionally compile the PerformanceCounters dependency, as this won't work on .net core.
* We cannot call `XmlConfigurator.Configure` directly when targeting the netstandard version of log4net. I'm not sure this is the correct way to do it, but due to missing dependencies, I haven't tested this yet.
* Pulling in the registry dependency when targeting .net core.