### PR TITLE
V7 broke SendLocal behavior, not allowed anymore on send-only endpoints

### DIFF
--- a/src/PerformanceTests/Common/Scenarios/GatedSendLocal/GatedSendLocalRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/GatedSendLocal/GatedSendLocalRunner.cs
@@ -11,7 +11,7 @@ class GatedSendLocalRunner : LoopRunner
 {
     protected override Task SendMessage(ISession session)
     {
-        return session.SendLocal(new Command
+        return session.Send(EndpointName, new Command
         {
             Data = Data
         });

--- a/src/PerformanceTests/Common/Scenarios/Receive/ReceiveRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/Receive/ReceiveRunner.cs
@@ -26,7 +26,7 @@ partial class ReceiveRunner : BaseRunner, ICreateSeedData
     public Task SendMessage(ISession session)
     {
         Interlocked.Increment(ref seedCount);
-        return session.SendLocal(new Command { Data = Data });
+        return session.Send(EndpointName, new Command { Data = Data });
     }
 
     static void Signal()

--- a/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLocalOneOnOne/SendLocalOneOnOneRunner.cs
@@ -14,7 +14,7 @@ partial class SendLocalOneOnOneRunner : PerpetualRunner
 {
     protected override Task Seed(int i, ISession session)
     {
-        return session.SendLocal(new Command { Data = Data });
+        return session.Send(EndpointName, new Command { Data = Data });
     }
 
     public class Command : ICommand

--- a/src/PerformanceTests/Common/Scenarios/SendLoop/SendLoop.cs
+++ b/src/PerformanceTests/Common/Scenarios/SendLoop/SendLoop.cs
@@ -10,7 +10,7 @@ abstract class SendLoop : BaseLoop
     }
     protected override Task SendMessage(ISession session)
     {
-        return session.SendLocal(new Command { Data = Data });
+        return session.Send(EndpointName, new Command { Data = Data });
     }
 
     class Command : ICommand

--- a/src/PerformanceTests/NServiceBus5/Session.cs
+++ b/src/PerformanceTests/NServiceBus5/Session.cs
@@ -4,7 +4,6 @@ using NServiceBus;
 class Session : ISession
 {
     readonly IBus instance;
-    readonly Address localAddress;
 
     public Session(IBus instance)
     {
@@ -14,32 +13,23 @@ class Session : ISession
     public Session(ISendOnlyBus instance)
     {
         this.instance = (IBus)instance;
-        var unicastBus = (NServiceBus.Unicast.UnicastBus)instance;
-        var machine = unicastBus.Configure.LocalAddress.Machine;
-        var queue = unicastBus.Configure.LocalAddress.Queue;
-
-        localAddress = new Address(queue, machine);
     }
 
-    public Task Send(object message)
+   public Task Send(object message)
     {
         instance.Send(message);
+        return Task.FromResult(0);
+    }
+
+    public Task Send(string destination, object message)
+    {
+        instance.Send(destination, message);
         return Task.FromResult(0);
     }
 
     public Task Publish(object message)
     {
         instance.Publish(message);
-        return Task.FromResult(0);
-    }
-
-    public Task SendLocal(object message)
-    {
-        if (localAddress == null)
-            instance.SendLocal(message);
-        else
-            instance.Send(localAddress, message);
-
         return Task.FromResult(0);
     }
 

--- a/src/PerformanceTests/NServiceBus6/Session.cs
+++ b/src/PerformanceTests/NServiceBus6/Session.cs
@@ -15,14 +15,14 @@ class Session : ISession
         return instance.Send(message);
     }
 
+    public Task Send(string destination, object message)
+    {
+        return instance.Send(destination, message);
+    }
+
     public Task Publish(object message)
     {
         return instance.Publish(message);
-    }
-
-    public Task SendLocal(object message)
-    {
-        return instance.SendLocal(message);
     }
 
     public Task Close()

--- a/src/PerformanceTests/NServiceBus7/Session.cs
+++ b/src/PerformanceTests/NServiceBus7/Session.cs
@@ -15,14 +15,14 @@ class Session : ISession
         return instance.Send(message);
     }
 
+    public Task Send(string destination, object message)
+    {
+        return instance.Send(destination, message);
+    }
+
     public Task Publish(object message)
     {
         return instance.Publish(message);
-    }
-
-    public Task SendLocal(object message)
-    {
-        return instance.SendLocal(message);
     }
 
     public Task Close()

--- a/src/PerformanceTests/Scenarios/SagaCongestion/SagaCongestionRunner.cs
+++ b/src/PerformanceTests/Scenarios/SagaCongestion/SagaCongestionRunner.cs
@@ -15,7 +15,7 @@ partial class SagaCongestionRunner
 {
     protected override Task Seed(int i, ISession session)
     {
-        return session.SendLocal(new Command { Identifier = 1, Data = Data });
+        return session.Send(EndpointName, new Command { Identifier = 1, Data = Data });
     }
 
     public class Command : ICommand

--- a/src/PerformanceTests/Scenarios/SagaInitiate/SagaInitiateRunner.cs
+++ b/src/PerformanceTests/Scenarios/SagaInitiate/SagaInitiateRunner.cs
@@ -6,7 +6,7 @@ partial class SagaInitiateRunner : BaseRunner, ICreateSeedData
 {
     public Task SendMessage(ISession session)
     {
-        return session.SendLocal(new Command { Identifier = Guid.NewGuid() });
+        return session.Send(EndpointName, new Command { Identifier = Guid.NewGuid() });
     }
 
     public class Command : ICommand

--- a/src/PerformanceTests/Scenarios/SagaUpdate/SagaUpdateRunner.cs
+++ b/src/PerformanceTests/Scenarios/SagaUpdate/SagaUpdateRunner.cs
@@ -6,7 +6,7 @@ partial class SagaUpdateRunner
 {
     protected override Task Seed(int i, ISession session)
     {
-        return session.SendLocal(new Command { Identifier = ++i, Data = Data });
+        return session.Send(EndpointName, new Command { Identifier = ++i, Data = Data });
     }
 
     public class Command : ICommand

--- a/src/PerformanceTests/Utils/ISession.cs
+++ b/src/PerformanceTests/Utils/ISession.cs
@@ -3,7 +3,7 @@
 public interface ISession
 {
     Task Send(object message);
+    Task Send(string destination, object message);
     Task Publish(object message);
-    Task SendLocal(object message);
     Task Close();
 }


### PR DESCRIPTION

V7 broke SendLocal behavior, not allowed anymore on send-only endpoints and this resulted in a few scenarios to break at runtime as this was used for easily seeding message to 'itself' while not yet processing any message. Seeding now uses the endpoint name as the address and passed via `Send(address, message)`.