### PR TITLE
Fix file copy sources

### DIFF
--- a/src/PerformanceTests/Tests/Tools/TestEnvironment.cs
+++ b/src/PerformanceTests/Tests/Tools/TestEnvironment.cs
@@ -43,10 +43,10 @@ namespace Tests.Tools
 
             startupDir.Create();
 
-            var sourceAssemblyFiles = Directory.GetFiles(components.RootProjectDirectory, "*", SearchOption.AllDirectories);
+            var sourceAssemblyFiles = Directory.GetFiles(components.HostDirectory, "*", SearchOption.AllDirectories);
             CopyAssembliesToStarupDir(startupDir, sourceAssemblyFiles, components.Directories);
 
-            var projectAssemblyPath = Path.Combine(startupDir.FullName, components.RootProjectDirectory + ".exe");
+            var projectAssemblyPath = Path.Combine(startupDir.FullName, components.HostAssemblyName + ".exe");
 
             var descriptor = new TestDescriptor
             {


### PR DESCRIPTION
as we're already multitargeting, the current file copy mechanism copies files from both targets into the test execution folder, causing weird assembly loading issues.

ping @ramonsmits 