### PR TITLE
Connectionstrings outside repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,4 @@ src/scaffolding.config
 
 # Approval tests temp file
 *.received.*
-.connectionstrings.config
+

--- a/src/PerformanceTests/NServiceBus5/NServiceBus5.csproj
+++ b/src/PerformanceTests/NServiceBus5/NServiceBus5.csproj
@@ -96,7 +96,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include=".connectionstrings.config">
+    <None Include="..\..\..\..\.connectionstrings.config">
+      <Link>.connectionstrings.config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="App.config">

--- a/src/PerformanceTests/NServiceBus5/NServiceBus5.csproj
+++ b/src/PerformanceTests/NServiceBus5/NServiceBus5.csproj
@@ -132,7 +132,8 @@
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>copy /-Y "$(SolutionDir).connectionstrings.config" "$(ProjectDir).connectionstrings.config"</PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\..\packages\Microsoft.VisualStudio.SlowCheetah.3.0.61\build\Microsoft.VisualStudio.SlowCheetah.targets" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.SlowCheetah.3.0.61\build\Microsoft.VisualStudio.SlowCheetah.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/PerformanceTests/NServiceBus6/NServiceBus6.csproj
+++ b/src/PerformanceTests/NServiceBus6/NServiceBus6.csproj
@@ -139,7 +139,8 @@
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>copy /-Y "$(SolutionDir).connectionstrings.config" "$(ProjectDir).connectionstrings.config"</PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\..\packages\Microsoft.VisualStudio.SlowCheetah.3.0.61\build\Microsoft.VisualStudio.SlowCheetah.targets" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.SlowCheetah.3.0.61\build\Microsoft.VisualStudio.SlowCheetah.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/PerformanceTests/NServiceBus6/NServiceBus6.csproj
+++ b/src/PerformanceTests/NServiceBus6/NServiceBus6.csproj
@@ -102,7 +102,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include=".connectionstrings.config">
+    <None Include="..\..\..\..\.connectionstrings.config">
+      <Link>.connectionstrings.config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="App.config">

--- a/src/PerformanceTests/NServiceBus7/NServiceBus7.csproj
+++ b/src/PerformanceTests/NServiceBus7/NServiceBus7.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../.connectionstrings.config">
+    <None Include="..\..\..\..\.connectionstrings.config" Link=".connectionstrings.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="App.config">
@@ -45,9 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update=".connectionstrings.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="App.Debug.config">
       <IsTransformFile>True</IsTransformFile>
     </None>

--- a/src/PerformanceTests/readme.md
+++ b/src/PerformanceTests/readme.md
@@ -56,9 +56,9 @@ All of these can be run locally except for Azure Service Bus. Azure Storage Queu
 
 # Connection strings
 
-All of these need a correct connection string. There is a connection string template file `.connectionstrings.config` at the location of the `readme.md`. This already contains a few connection strings to access all services locally expect for Azure Service Bus.
+All of these tests need a correct connection string. There is a connection string template file `.connectionstrings.config` at the location of the `readme.md`. This already contains a few connection strings to access all services locally expect for Azure Service Bus.
 
-This template file is copied to two projects during the pre build when they do not exist yet. These files are NOT stored in the repository and are ignored. You can safely edit these and store your own connection strings.
+This file needs to be copied one level above the repository folder, as this is the location from where the host projects link to. This was your custom values are not stored in the repository folder itself and your data cannot be accidentally committed. Another benefit is that you can easilly execute `git clean -xfd`.
 
 # Run it locally
 


### PR DESCRIPTION
Host for v7 contained a double entry which is removed. The host projects now link to a connection string file outside of the repo. This way we can perform a future build on linux too but custom connection string values wil not indicate a change in the repo.