### PR TITLE
Logging progress of seeding of invidual batches

### DIFF
--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -132,7 +132,7 @@ public abstract partial class BaseRunner : IContext
                     }).ConfigureAwait(false);
                 Interlocked.Add(ref count, currentBatchSize);
                 var duration = sw.ElapsedMilliseconds;
-                Log.InfoFormat("Batch with size {0,7:N0} duration {1,7:N0}ms", batchSize, duration);
+                Log.InfoFormat("Batch completed with size {0,7:N0} duration {1,7:N0}ms", batchSize, duration);
                 if (duration < MinimumBatchSeedDuration)
                 {
                     batchSize = currentBatchSize * 2; // Last writer wins

--- a/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/BaseRunner.cs
@@ -132,6 +132,7 @@ public abstract partial class BaseRunner : IContext
                     }).ConfigureAwait(false);
                 Interlocked.Add(ref count, currentBatchSize);
                 var duration = sw.ElapsedMilliseconds;
+                Log.InfoFormat("Batch with size {0,7:N0} duration {1,7:N0}ms", batchSize, duration);
                 if (duration < MinimumBatchSeedDuration)
                 {
                     batchSize = currentBatchSize * 2; // Last writer wins

--- a/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
@@ -66,6 +66,7 @@ abstract class LoopRunner : BaseRunner
                     count += batchSize;
 
                     var duration = batchDuration.ElapsedMilliseconds;
+                    Log.InfoFormat("Batch with size {0,7:N0} duration {1,7:N0}ms", batchSize, duration);
                     if (duration < MinimumBatchSeedDuration)
                     {
                         batchSize *= 2;

--- a/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
+++ b/src/PerformanceTests/Common/Scenarios/LoopRunner.cs
@@ -66,7 +66,7 @@ abstract class LoopRunner : BaseRunner
                     count += batchSize;
 
                     var duration = batchDuration.ElapsedMilliseconds;
-                    Log.InfoFormat("Batch with size {0,7:N0} duration {1,7:N0}ms", batchSize, duration);
+                    Log.InfoFormat("Batch completed with size {0,7:N0} duration {1,7:N0}ms", batchSize, duration);
                     if (duration < MinimumBatchSeedDuration)
                     {
                         batchSize *= 2;


### PR DESCRIPTION
Based on feedback by @timbussmann that asked a question about the following log entries and thought that after the batch size increment only a single batch of messages was seeded.
```
2017-11-22 09:04:44,212|INFO|11|BaseRunner|Increasing seed batch size to   2,048 as sending took   1,884ms which is less then 2,500ms
2017-11-22 09:05:08,066|INFO|18|BaseRunner|Done seeding, seeded 13,824 messages, 516.3 msg/s
```