### PR TITLE
Get the tests to run

### DIFF
--- a/src/TransportCompatibilityTests/AmazonSQSV3/AmazonSQSV3.csproj
+++ b/src/TransportCompatibilityTests/AmazonSQSV3/AmazonSQSV3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TransportCompatibilityTests/AmazonSQSV3/EndpointFacade.cs
+++ b/src/TransportCompatibilityTests/AmazonSQSV3/EndpointFacade.cs
@@ -7,7 +7,7 @@
     using TransportCompatibilityTests.Common.AmazonSQS;
     using TransportCompatibilityTests.Common.Messages;
 
-    public class EndpointFacade : IEndpointFacade
+    public class EndpointFacade : MarshalByRefObject, IEndpointFacade
     {
         MessageStore messageStore;
         CallbackResultStore callbackResultStore;
@@ -40,6 +40,7 @@
             endpointConfiguration.EnableInstallers();
 
             var transportExtensions = endpointConfiguration.UseTransport<SqsTransport>();
+            transportExtensions.Region("us-east-1");
 
             endpointConfiguration.SendFailedMessagesTo("error");
             endpointConfiguration.AuditProcessedMessagesTo("audit");

--- a/src/TransportCompatibilityTests/AmazonSQSV4/AmazonSQSV4.csproj
+++ b/src/TransportCompatibilityTests/AmazonSQSV4/AmazonSQSV4.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.0.0-beta0012" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="4.0.0-beta0007" />
+    <PackageReference Include="NServiceBus.Callbacks" Version="3.0.0-beta0003" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TransportCompatibilityTests.Common\TransportCompatibilityTests.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/TransportCompatibilityTests/AmazonSQSV4/EndpointFacade.cs
+++ b/src/TransportCompatibilityTests/AmazonSQSV4/EndpointFacade.cs
@@ -1,0 +1,132 @@
+﻿namespace AmazonSQSV4
+{
+    using System;
+    using System.Threading.Tasks;
+    using Amazon;
+    using Amazon.S3;
+    using Amazon.SQS;
+    using NServiceBus;
+    using TransportCompatibilityTests.Common;
+    using TransportCompatibilityTests.Common.AmazonSQS;
+    using TransportCompatibilityTests.Common.Messages;
+
+    public class EndpointFacade : MarshalByRefObject, IEndpointFacade
+    {
+        MessageStore messageStore;
+        CallbackResultStore callbackResultStore;
+        IEndpointInstance endpointInstance;
+        SubscriptionStore subscriptionStore;
+
+        public void Dispose()
+        {
+            endpointInstance.Stop().GetAwaiter().GetResult();
+        }
+
+        public void Bootstrap(EndpointDefinition endpointDefinition)
+        {
+            InitializeEndpoint(endpointDefinition.As<AmazonSQSEndpointDefinition>())
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        async Task InitializeEndpoint(AmazonSQSEndpointDefinition endpointDefinition)
+        {
+            try
+            {
+                var endpointConfiguration = new EndpointConfiguration(endpointDefinition.Name);
+
+                endpointConfiguration.Conventions()
+                    .DefiningMessagesAs(
+                        t => t.Namespace != null && t.Namespace.EndsWith(".Messages") && t != typeof(TestEvent));
+                endpointConfiguration.Conventions().DefiningEventsAs(t => t == typeof(TestEvent));
+                endpointConfiguration.Conventions().DefiningCommandsAs(t => t.FullName.EndsWith("Command"));
+
+                endpointConfiguration.UsePersistence<InMemoryPersistence>();
+                endpointConfiguration.EnableInstallers();
+
+                var transportExtensions = endpointConfiguration.UseTransport<SqsTransport>();
+                transportExtensions.ClientFactory(() => new AmazonSQSClient(new AmazonSQSConfig
+                {
+                    RegionEndpoint = RegionEndpoint.USEast1
+                }));
+                transportExtensions.S3("transport-compat-tests", "TCC").ClientFactory(() => new AmazonS3Client(new AmazonS3Config()
+                {
+                    RegionEndpoint = RegionEndpoint.USEast1
+                }));
+
+                endpointConfiguration.SendFailedMessagesTo("error");
+                endpointConfiguration.AuditProcessedMessagesTo("audit");
+
+                endpointConfiguration.EnableCallbacks();
+
+                var routing = transportExtensions.Routing();
+                foreach (var mapping in endpointDefinition.Mappings)
+                {
+                    routing.RouteToEndpoint(mapping.MessageType, mapping.TransportAddress);
+                }
+
+                foreach (var publisher in endpointDefinition.Publishers)
+                {
+                    routing.RegisterPublisher(publisher.MessageType, publisher.TransportAddress);
+                }
+
+                endpointConfiguration.MakeInstanceUniquelyAddressable("A");
+
+                messageStore = new MessageStore();
+                callbackResultStore = new CallbackResultStore();
+                subscriptionStore = new SubscriptionStore();
+
+                endpointConfiguration.RegisterComponents(c => c.RegisterSingleton(messageStore));
+                endpointConfiguration.RegisterComponents(c => c.RegisterSingleton(subscriptionStore));
+
+                endpointInstance = await Endpoint.Start(endpointConfiguration);
+            }
+            catch (Exception e)
+            {
+                throw new Exception(e.ToString());
+            }
+        }
+
+        public void SendCommand(Guid messageId)
+        {
+            endpointInstance.Send(new TestCommand { Id = messageId }).GetAwaiter().GetResult();
+        }
+
+        public void SendRequest(Guid requestId)
+        {
+            endpointInstance.Send(new TestRequest { RequestId = requestId }).GetAwaiter().GetResult();
+        }
+
+        public void PublishEvent(Guid eventId)
+        {
+            endpointInstance.Publish(new TestEvent { EventId = eventId }).GetAwaiter().GetResult();
+        }
+
+        public void SendAndCallbackForInt(int value)
+        {
+            Task.Run(async () =>
+            {
+                var result = await endpointInstance.Request<int>(new TestIntCallback { Response = value }, new SendOptions());
+
+                callbackResultStore.Add(result);
+            });
+        }
+
+        public void SendAndCallbackForEnum(CallbackEnum value)
+        {
+            Task.Run(async () =>
+            {
+                var result = await endpointInstance.Request<CallbackEnum>(new TestEnumCallback { CallbackEnum = value }, new SendOptions());
+
+                callbackResultStore.Add(result);
+            });
+        }
+
+        public Guid[] ReceivedMessageIds => messageStore.GetAll();
+        public Guid[] ReceivedResponseIds => messageStore.Get<TestResponse>();
+        public Guid[] ReceivedEventIds => messageStore.Get<TestEvent>();
+        public int[] ReceivedIntCallbacks => callbackResultStore.Get<int>();
+        public CallbackEnum[] ReceivedEnumCallbacks => callbackResultStore.Get<CallbackEnum>();
+        public int NumberOfSubscriptions => subscriptionStore.NumberOfSubscriptions;
+    }
+}

--- a/src/TransportCompatibilityTests/AmazonSQSV4/EndpointFacade.cs
+++ b/src/TransportCompatibilityTests/AmazonSQSV4/EndpointFacade.cs
@@ -6,6 +6,7 @@
     using Amazon.S3;
     using Amazon.SQS;
     using NServiceBus;
+    using NServiceBus.Pipeline;
     using TransportCompatibilityTests.Common;
     using TransportCompatibilityTests.Common.AmazonSQS;
     using TransportCompatibilityTests.Common.Messages;
@@ -49,7 +50,7 @@
                 {
                     RegionEndpoint = RegionEndpoint.USEast1
                 }));
-                transportExtensions.S3("transport-compat-tests", "TCC").ClientFactory(() => new AmazonS3Client(new AmazonS3Config()
+                transportExtensions.S3("transport-compat-tests", "TCC").ClientFactory(() => new AmazonS3Client(new AmazonS3Config
                 {
                     RegionEndpoint = RegionEndpoint.USEast1
                 }));
@@ -78,6 +79,8 @@
 
                 endpointConfiguration.RegisterComponents(c => c.RegisterSingleton(messageStore));
                 endpointConfiguration.RegisterComponents(c => c.RegisterSingleton(subscriptionStore));
+
+                endpointConfiguration.Pipeline.Register<SubscriptionMonitoringBehavior.Registration>();
 
                 endpointInstance = await Endpoint.Start(endpointConfiguration);
             }
@@ -128,5 +131,30 @@
         public int[] ReceivedIntCallbacks => callbackResultStore.Get<int>();
         public CallbackEnum[] ReceivedEnumCallbacks => callbackResultStore.Get<CallbackEnum>();
         public int NumberOfSubscriptions => subscriptionStore.NumberOfSubscriptions;
+
+        class SubscriptionMonitoringBehavior : Behavior<IIncomingPhysicalMessageContext>
+        {
+            public SubscriptionStore SubscriptionStore { get; set; }
+
+            public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
+            {
+                await next();
+                string intent;
+
+                if (context.Message.Headers.TryGetValue(Headers.MessageIntent, out intent) && intent == "Subscribe")
+                {
+                    SubscriptionStore.Increment();
+                }
+            }
+
+            internal class Registration : RegisterStep
+            {
+                public Registration()
+                    : base("SubscriptionBehavior", typeof(SubscriptionMonitoringBehavior), "So we can get subscription events")
+                {
+                    InsertBefore("ProcessSubscriptionRequests");
+                }
+            }
+        }
     }
 }

--- a/src/TransportCompatibilityTests/AmazonSQSV4/Handler.cs
+++ b/src/TransportCompatibilityTests/AmazonSQSV4/Handler.cs
@@ -1,4 +1,4 @@
-﻿namespace AmazonSQSV3
+﻿namespace AmazonSQSV4
 {
     using System.Threading.Tasks;
     using NServiceBus;

--- a/src/TransportCompatibilityTests/TransportCompatibilityTests.Common/AmazonSQS/AmazonSQSEndpointDefinition.cs
+++ b/src/TransportCompatibilityTests/TransportCompatibilityTests.Common/AmazonSQS/AmazonSQSEndpointDefinition.cs
@@ -1,5 +1,8 @@
 ﻿namespace TransportCompatibilityTests.Common.AmazonSQS
 {
+    using System;
+
+    [Serializable]
     public class AmazonSQSEndpointDefinition : EndpointDefinition
     {
         public override string TransportName => "AmazonSQS";

--- a/src/TransportCompatibilityTests/TransportCompatibilityTests.Common/Conventions.cs
+++ b/src/TransportCompatibilityTests/TransportCompatibilityTests.Common/Conventions.cs
@@ -21,7 +21,7 @@
 
                 var assemblyName = AssemblyNameResolver(definition, version);
                 //Hard-coding net452 since the test project itself is hard-coded to that framework
-                var newStyle = Path.Combine(TestContext.CurrentContext.TestDirectory, $"..\\..\\..\\{assemblyName}\\bin\\{configuration}\\net452"); ;
+                var newStyle = Path.Combine(TestContext.CurrentContext.TestDirectory, $"..\\..\\..\\{assemblyName}\\bin\\{configuration}\\net452");
                 if (Directory.Exists(newStyle))
                 {
                     return newStyle;

--- a/src/TransportCompatibilityTests/TransportCompatibilityTests.Common/Conventions.cs
+++ b/src/TransportCompatibilityTests/TransportCompatibilityTests.Common/Conventions.cs
@@ -20,8 +20,14 @@
                 #endif
 
                 var assemblyName = AssemblyNameResolver(definition, version);
-                var combine = Path.Combine(TestContext.CurrentContext.TestDirectory, $"..\\..\\..\\{assemblyName}\\bin\\{configuration}");
-                return combine;
+                //Hard-coding net452 since the test project itself is hard-coded to that framework
+                var newStyle = Path.Combine(TestContext.CurrentContext.TestDirectory, $"..\\..\\..\\{assemblyName}\\bin\\{configuration}\\net452"); ;
+                if (Directory.Exists(newStyle))
+                {
+                    return newStyle;
+                }
+                var oldStyle = Path.Combine(TestContext.CurrentContext.TestDirectory, $"..\\..\\..\\{assemblyName}\\bin\\{configuration}");
+                return oldStyle;
             };
 
         public static Func<EndpointDefinition, int, string> AssemblyPathResolver =

--- a/src/TransportCompatibilityTests/TransportCompatibilityTests.sln
+++ b/src/TransportCompatibilityTests/TransportCompatibilityTests.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SqlServer", "SqlServer", "{730F50BD-97CE-4A53-A074-01A7AEFA0FFB}"
 EndProject
@@ -47,7 +47,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureServiceBusV8", "AzureS
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AmazonSQS", "AmazonSQS", "{5112C083-37E1-4046-AB33-CABDB0F8C106}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AmazonSQSV3", "AmazonSQSV3\AmazonSQSV3.csproj", "{4C2248A8-B469-4341-A138-728D2079707A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AmazonSQSV3", "AmazonSQSV3\AmazonSQSV3.csproj", "{4C2248A8-B469-4341-A138-728D2079707A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AmazonSQSV4", "AmazonSQSV4\AmazonSQSV4.csproj", "{77A80968-887C-4DEF-8001-51BA426CCD4E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -127,6 +129,10 @@ Global
 		{4C2248A8-B469-4341-A138-728D2079707A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4C2248A8-B469-4341-A138-728D2079707A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4C2248A8-B469-4341-A138-728D2079707A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77A80968-887C-4DEF-8001-51BA426CCD4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77A80968-887C-4DEF-8001-51BA426CCD4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77A80968-887C-4DEF-8001-51BA426CCD4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77A80968-887C-4DEF-8001-51BA426CCD4E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,6 +154,7 @@ Global
 		{0EC36A5A-D932-4DE3-B9B0-97E280F5DDE5} = {2D1C1288-7385-4410-8F6E-AF57D0FAA8BC}
 		{9136FE74-F473-4265-BD0B-8A5B8ABD69CF} = {D9F4ACD7-CA95-429F-8121-01CF783747EF}
 		{4C2248A8-B469-4341-A138-728D2079707A} = {5112C083-37E1-4046-AB33-CABDB0F8C106}
+		{77A80968-887C-4DEF-8001-51BA426CCD4E} = {5112C083-37E1-4046-AB33-CABDB0F8C106}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4499F4CC-1518-41B1-BE63-5B1E4E05DA95}

--- a/src/TransportCompatibilityTests/TransportCompatibilityTests/AmazonSQS/Callbacks.cs
+++ b/src/TransportCompatibilityTests/TransportCompatibilityTests/AmazonSQS/Callbacks.cs
@@ -73,14 +73,13 @@
 
         static object[][] GenerateVersionsPairs()
         {
-            var sqlTransportVersions = new[]
+            var versions = new[]
             {
                 3,
-                4
             };
 
-            var pairs = from l in sqlTransportVersions
-                        from r in sqlTransportVersions
+            var pairs = from l in versions
+                        from r in versions
                         where l != r
                         select new object[] { l, r };
 

--- a/src/TransportCompatibilityTests/TransportCompatibilityTests/AmazonSQS/Callbacks.cs
+++ b/src/TransportCompatibilityTests/TransportCompatibilityTests/AmazonSQS/Callbacks.cs
@@ -76,6 +76,7 @@
             var versions = new[]
             {
                 3,
+                4
             };
 
             var pairs = from l in versions

--- a/src/TransportCompatibilityTests/TransportCompatibilityTests/AmazonSQS/MessageExchangePatterns.cs
+++ b/src/TransportCompatibilityTests/TransportCompatibilityTests/AmazonSQS/MessageExchangePatterns.cs
@@ -99,8 +99,7 @@
         {
             var transportVersions = new[]
             {
-                3,
-                4
+                3
             };
 
             var pairs = from l in transportVersions

--- a/src/TransportCompatibilityTests/TransportCompatibilityTests/AmazonSQS/MessageExchangePatterns.cs
+++ b/src/TransportCompatibilityTests/TransportCompatibilityTests/AmazonSQS/MessageExchangePatterns.cs
@@ -99,7 +99,8 @@
         {
             var transportVersions = new[]
             {
-                3
+                3,
+                4
             };
 
             var pairs = from l in transportVersions


### PR DESCRIPTION
 * Changed the target to `net452` since the main test project targets `net452`
 * Hard-coded the assembly path convention to look for `net452`. This and the above needs to be solved properly when we want to be able to run on .NET core
 * Minor fixes to the abstraction types
 * Removed (for now) version 4 from the list
 * Hard-coded (for now) the region to `us-east-1`
  